### PR TITLE
Cleaned up travis configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,20 @@
+#-----------------------------------------------------------------------------
+# Enable C++ language
+#-----------------------------------------------------------------------------
 language: cpp
 
+#-----------------------------------------------------------------------------
+# Branches to run
+#-----------------------------------------------------------------------------
+branches:
+  except:
+    - prototype/.*
+    - gh-pages
+
+
+#-----------------------------------------------------------------------------
+# Build Configurations
+#-----------------------------------------------------------------------------
 matrix:
   include:
     # Linux gcc-6
@@ -11,6 +26,7 @@ matrix:
           packages: ['g++-6']
       env:
         - TOOLSET=g++-6 BUILD_TYPE='Debug'
+
     - os: linux
       compiler: gcc
       addons:
@@ -24,25 +40,32 @@ matrix:
     - os: osx
       compiler: clang
       env: TOOLSET=clang++ BUILD_TYPE='Debug'
+
     - os: osx
       compiler: clang
       env: TOOLSET=clang++ BUILD_TYPE='Release'
 
+#-----------------------------------------------------------------------------
+# Installation Steps
+#-----------------------------------------------------------------------------
 install:
   - cd ../
 
   # Get dependency 'catch'
   - mkdir -p catch/include
-  - wget https://github.com/philsquared/Catch/releases/download/v1.8.1/catch.hpp -P catch/include
+  - wget https://github.com/philsquared/Catch/releases/download/v1.10.0/catch.hpp -P catch/include
   - export CATCH_DIR=$(pwd)/catch/include
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-check-certificate https://www.cmake.org/files/v3.3/cmake-3.3.1-Linux-x86_64.tar.gz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xzf cmake-3.3.1-Linux-x86_64.tar.gz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.3.1-Linux-x86_64/bin/cmake; fi
-
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://cmake.org/files/v3.3/cmake-3.3.0-Darwin-x86_64.tar.gz; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar -xzf cmake-3.3.0-Darwin-x86_64.tar.gz && ls && ls cmake-3.3.0-Darwin-x86_64; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.3.0-Darwin-x86_64/CMake.app/Contents/bin/cmake; fi
+  # Install cmake 3.9.4 for Linux or OSX
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  -   wget --no-check-certificate https://www.cmake.org/files/v3.9/cmake-3.9.4-Linux-x86_64.tar.gz
+  -   tar -xzf cmake-3.9.4-Linux-x86_64.tar.gz
+  -   export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Linux-x86_64/bin/cmake
+  - elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  -   wget --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.4-Darwin-x86_64.tar.gz
+  -   tar -xzf cmake-3.9.4-Darwin-x86_64.tar.gz && ls && ls cmake-3.9.4-Darwin-x86_64
+  -   export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Darwin-x86_64/CMake.app/Contents/bin/cmake
+  - fi
 
   - export CXX=$TOOLSET
   - $CXX --version
@@ -50,6 +73,9 @@ install:
 
   - cd bit-memory/
 
+#-----------------------------------------------------------------------------
+# Build Step
+#-----------------------------------------------------------------------------
 script:
   - mkdir build/ && cd build/
   - echo $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MEMORY_COMPILE_UNIT_TESTS=On

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,16 +56,15 @@ install:
   - wget https://github.com/philsquared/Catch/releases/download/v1.10.0/catch.hpp -P catch/include
   - export CATCH_DIR=$(pwd)/catch/include
 
-  # Install cmake 3.9.4 for Linux or OSX
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  -   wget --no-check-certificate https://www.cmake.org/files/v3.9/cmake-3.9.4-Linux-x86_64.tar.gz
-  -   tar -xzf cmake-3.9.4-Linux-x86_64.tar.gz
-  -   export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Linux-x86_64/bin/cmake
-  - elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-  -   wget --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.4-Darwin-x86_64.tar.gz
-  -   tar -xzf cmake-3.9.4-Darwin-x86_64.tar.gz && ls && ls cmake-3.9.4-Darwin-x86_64
-  -   export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Darwin-x86_64/CMake.app/Contents/bin/cmake
-  - fi
+  # Install cmake 3.9.4 for Linux
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-check-certificate https://www.cmake.org/files/v3.9/cmake-3.9.4-Linux-x86_64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xzf cmake-3.9.4-Linux-x86_64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Linux-x86_64/bin/cmake; fi
+
+  # Install cmake 3.9.4 for MacOS
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget --no-check-certificate https://cmake.org/files/v3.9/cmake-3.9.4-Darwin-x86_64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tar -xzf cmake-3.9.4-Darwin-x86_64.tar.gz && ls && ls cmake-3.9.4-Darwin-x86_64; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CMAKE=$TRAVIS_BUILD_DIR/../cmake-3.9.4-Darwin-x86_64/CMake.app/Contents/bin/cmake; fi
 
   - export CXX=$TOOLSET
   - $CXX --version


### PR DESCRIPTION
Updating travis configurations to ignore `gh-pages` , and any `prototype/` branches.

This additionally does the following:
- Updates `cmake` version
- Updates `catch` version
- Cleans up `.travis.yml` layout