### PR TITLE
Fixed allocator ownership

### DIFF
--- a/include/bit/memory/allocator_traits.hpp
+++ b/include/bit/memory/allocator_traits.hpp
@@ -158,7 +158,7 @@ namespace bit {
       ///
       /// \param alloc the allocator
       /// \param p the pointer
-      static bool owns( Allocator& alloc, const_pointer p ) noexcept;
+      static bool owns( const Allocator& alloc, const_pointer p ) noexcept;
 
       /// \brief Gets the name of the specified allocator
       ///

--- a/include/bit/memory/allocators/bump_down_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_allocator.hpp
@@ -111,7 +111,7 @@ namespace bit {
       ///
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
-      bool owns( void* p ) const noexcept;
+      bool owns( const void* p ) const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
@@ -115,7 +115,7 @@ namespace bit {
       ///
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
-      bool owns( void* p ) const noexcept;
+      bool owns( const void* p ) const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/bump_up_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_allocator.hpp
@@ -103,7 +103,7 @@ namespace bit {
       ///
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
-      bool owns( void* p ) const noexcept;
+      bool owns( const void* p ) const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
@@ -115,7 +115,7 @@ namespace bit {
       ///
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
-      bool owns( void* p ) const noexcept;
+      bool owns( const void* p ) const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/detail/bump_down_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_down_allocator.inl
@@ -68,7 +68,7 @@ inline void bit::memory::bump_down_allocator::deallocate_all()
 // Observers
 //----------------------------------------------------------------------------
 
-inline bool bit::memory::bump_down_allocator::owns( void* p )
+inline bool bit::memory::bump_down_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;

--- a/include/bit/memory/allocators/detail/bump_down_lifo_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_down_lifo_allocator.inl
@@ -85,7 +85,7 @@ inline void bit::memory::bump_down_lifo_allocator::deallocate_all()
 // Observers
 //----------------------------------------------------------------------------
 
-inline bool bit::memory::bump_down_lifo_allocator::owns( void* p )
+inline bool bit::memory::bump_down_lifo_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;

--- a/include/bit/memory/allocators/detail/bump_up_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_up_allocator.inl
@@ -72,7 +72,7 @@ inline void bit::memory::bump_up_allocator::deallocate_all()
 // Observers
 //----------------------------------------------------------------------------
 
-inline bool bit::memory::bump_up_allocator::owns( void* p )
+inline bool bit::memory::bump_up_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;

--- a/include/bit/memory/allocators/detail/bump_up_lifo_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_up_lifo_allocator.inl
@@ -84,7 +84,7 @@ inline void bit::memory::bump_up_lifo_allocator::deallocate_all()
 // Observers
 //----------------------------------------------------------------------------
 
-inline bool bit::memory::bump_up_lifo_allocator::owns( void* p )
+inline bool bit::memory::bump_up_lifo_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;

--- a/include/bit/memory/allocators/detail/policy_allocator.inl
+++ b/include/bit/memory/allocators/detail/policy_allocator.inl
@@ -139,7 +139,7 @@ bool bit::memory::policy_allocator<ExtendedAllocator,Tagger,Tracker,Checker,Lock
   ::owns( const void* p )
   const noexcept
 {
-  auto& allocator = detail::get<0>(*this);
+  const auto& allocator = detail::get<0>(*this);
 
   return allocator_traits<ExtendedAllocator>::owns( allocator, p );
 }

--- a/include/bit/memory/allocators/detail/stack_allocator.inl
+++ b/include/bit/memory/allocators/detail/stack_allocator.inl
@@ -92,7 +92,7 @@ inline void bit::memory::stack_allocator<Size,Align>::deallocate_all()
 //-----------------------------------------------------------------------------
 
 template<std::size_t Size, std::size_t Align>
-inline bool bit::memory::stack_allocator<Size,Align>::owns( void* p )
+inline bool bit::memory::stack_allocator<Size,Align>::owns( const void* p )
   const noexcept
 {
   return static_cast<const void*>(&m_storage[0]) <= p && p < static_cast<const void*>(&m_storage[Size]);

--- a/include/bit/memory/allocators/stack_allocator.hpp
+++ b/include/bit/memory/allocators/stack_allocator.hpp
@@ -108,7 +108,7 @@ namespace bit {
       ///
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
-      bool owns( void* p ) const noexcept;
+      bool owns( const void* p ) const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/detail/allocator_traits.inl
+++ b/include/bit/memory/detail/allocator_traits.inl
@@ -80,7 +80,7 @@ inline void bit::memory::allocator_traits<Allocator>
 
 template<typename Allocator>
 inline bool bit::memory::allocator_traits<Allocator>
-  ::owns( Allocator& alloc, const_pointer p )
+  ::owns( const Allocator& alloc, const_pointer p )
   noexcept
 {
   return alloc.owns(p);


### PR DESCRIPTION
Various allocators and `allocator_traits` were incorrectly accepting non-`const` pointers in the `owns( ... )` allocator functions.