### PR TITLE
Updated cmake scripts submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,12 +5,9 @@ os: Visual Studio 2017
 build:
   verbosity: detailed
 
-configuration: Debug
-
-environment:
-  matrix:
-    - BUILD_UNIT_TESTS: true
-    - BUILD_INDEPENDENCE_TESTS: true
+configuration:
+  - Debug
+  - Release
 
 init: []
 
@@ -61,8 +58,8 @@ before_build:
 build_script:
   - mkdir build
   - cd build
-  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_INCLUDE_PATH=%CATCH_DIR% -DCMAKE_CXX_FLAGS="-fms-compatibility-version=19 -Wall -Wextra -pedantic -Xclang -fexceptions -Xclang -fcxx-exceptions -Xclang -fnew-ms-eh" -DBIT_MEMORY_COMPILE_UNIT_TESTS=%BUILD_UNIT_TESTS% -DBIT_MEMORY_COMPILE_INDEPENDENCE_TESTS=%BUILD_INDEPENDENCE_TESTS%
-  - cmake --build . --config Release
+  - cmake .. -GNinja -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_INCLUDE_PATH=%CATCH_DIR% -DCMAKE_CXX_FLAGS="-fms-compatibility-version=19 -Wall -Wextra -pedantic -Xclang -fexceptions -Xclang -fcxx-exceptions -Xclang -fnew-ms-eh" -DBIT_MEMORY_COMPILE_UNIT_TESTS=On -DBIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS=On
+  - cmake --build . --config %CONFIGURATION%
 
 test_script:
   - cmake --build . --target test

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,7 @@ install:
 #-----------------------------------------------------------------------------
 script:
   - mkdir build/ && cd build/
-  - echo $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MEMORY_COMPILE_UNIT_TESTS=On
-  - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MEMORY_COMPILE_UNIT_TESTS=On
+  - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS=On -DBIT_MEMORY_COMPILE_UNIT_TESTS=On
   - $CMAKE --build .
   - ./test/memory_test
   - $CMAKE --build . --target test

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,5 +79,5 @@ script:
   - mkdir build/ && cd build/
   - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS=On -DBIT_MEMORY_COMPILE_UNIT_TESTS=On
   - $CMAKE --build .
-  - ./test/memory_test
+  - ./test/bit_memory_test
   - $CMAKE --build . --target test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,16 @@ enable_testing()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
-include(AddIndependenceCheck)
+include(AddHeaderSelfContainmentTest)
 include(MakeVersionHeader)
+include(CopyTargetProperties)
 
 #-----------------------------------------------------------------------------
 # Project Setup
 #-----------------------------------------------------------------------------
 
-option(BIT_MEMORY_COMPILE_INDEPENDENCE_TESTS "Include each header independently in a .cpp file to determine header independence" on)
-option(BIT_MEMORY_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" on)
+option(BIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS "Include each header independently in a .cpp file to determine header self-containment" off)
+option(BIT_MEMORY_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" off)
 option(BIT_MEMORY_GENERATE_DOCUMENTATION "Generates doxygen documentation" off)
 
 project("BitMemory")
@@ -247,46 +248,45 @@ set(source_files
 # bit::memory: Library
 #-----------------------------------------------------------------------------
 
-add_library(memory ${source_files} ${headers} ${inline_headers})
-add_library(bit::memory ALIAS memory)
+add_library(bit_memory ${source_files} ${headers} ${inline_headers})
+add_library(bit::memory ALIAS bit_memory)
 
 # Add include directories
-target_include_directories(memory PUBLIC
+target_include_directories(bit_memory PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
 )
 
 # Add DEBUG, NDEBUG, and RELEASE macro definitions
-target_compile_definitions(memory PUBLIC
+target_compile_definitions(bit_memory PUBLIC
   $<$<CONFIG:DEBUG>:DEBUG>
   $<$<CONFIG:RELEASE>:DEBUG RELEASE>
 )
 
 # Add compiler-specific flags
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  target_compile_options(memory PUBLIC -Wall -Wstrict-aliasing -pedantic)
+  target_compile_options(bit_memory PUBLIC -Wall -Wstrict-aliasing -pedantic)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-  target_compile_options(memory PUBLIC -Wall -Wstrict-aliasing -pedantic)
+  target_compile_options(bit_memory PUBLIC -Wall -Wstrict-aliasing -pedantic)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
   # TODO: Determine MSVC necessary compiler flags
 endif()
 
 #-----------------------------------------------------------------------------
-# bit::memory : Independence Tests
+# bit::memory : Header-self-containment Tests
 #-----------------------------------------------------------------------------
 
-if( BIT_MEMORY_COMPILE_INDEPENDENCE_TESTS )
+if( BIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS )
 
-  add_independence_check(memory_independence ${headers})
+  # Add containment test and alias as 'bit::memory::header_self_containment_test
+  add_header_self_containment_test(bit_memory_header_self_containment_test ${headers})
+  add_library(bit::memory::header_self_containment_test ALIAS bit_memory_header_self_containment_test)
 
-  target_compile_definitions(memory_independence PUBLIC
-    $<$<CONFIG:DEBUG>:DEBUG>
-    $<$<CONFIG:RELEASE>:DEBUG RELEASE>
+  copy_target_properties(bit_memory_header_self_containment_test bit_memory PROPERTIES
+    COMPILE_DEFINITIONS
+    COMPILE_OPTIONS
+    INCLUDE_DIRECTORIES
   )
-
-  target_include_directories(memory_independence PRIVATE $<TARGET_PROPERTY:memory,INCLUDE_DIRECTORIES>)
-
-  add_library(bit::memory::independence ALIAS memory_independence)
 
 endif()
 
@@ -316,7 +316,7 @@ if( EXISTS "$ENV{BIT_HOME}" )
   set(CMAKE_INSTALL_PREFIX "$ENV{BIT_HOME}")
 endif()
 
-export_library( TARGETS memory
+export_library( TARGETS bit_memory
                 PACKAGE Memory
                 VERSION ${BIT_MEMORY_VERSION}
                 MAJOR_VERSION ${BIT_MEMORY_VERSION_MAJOR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,9 +26,9 @@ set(source_files
   ${platform_source_files}
 )
 
-add_executable(memory_test ${source_files})
+add_executable(bit_memory_test ${source_files})
 
-target_link_libraries(memory_test PRIVATE "bit::memory" "philsquared::Catch")
+target_link_libraries(bit_memory_test PRIVATE "bit::memory" "philsquared::Catch")
 
 #-----------------------------------------------------------------------------
 # Testing
@@ -36,10 +36,10 @@ target_link_libraries(memory_test PRIVATE "bit::memory" "philsquared::Catch")
 
 add_test( NAME "memory_test_default"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND "$<TARGET_FILE:memory_test>" )
+          COMMAND "$<TARGET_FILE:bit_memory_test>" )
 
 #-----------------------------------------------------------------------------
 
 add_test( NAME "memory_test_all"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND "$<TARGET_FILE:memory_test>" "*" )
+          COMMAND "$<TARGET_FILE:bit_memory_test>" "*" )


### PR DESCRIPTION
This updates the cmake submodule, and the scripts.

The `CMakeLists.txt` has also been updated to disable unit tests and header self-containment tests by default. 