### PR TITLE
Feature/any allocator adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(headers
   include/bit/memory/owner.hpp
   include/bit/memory/pointer_utilities.hpp
   include/bit/memory/std_allocator_adapter.hpp
+  include/bit/memory/std_any_allocator_adapter.hpp
   include/bit/memory/unaligned_memory.hpp
   include/bit/memory/uninitialized_storage.hpp
   include/bit/memory/virtual_memory.hpp
@@ -158,6 +159,7 @@ set(inline_headers
   include/bit/memory/detail/not_null.inl
   include/bit/memory/detail/pointer_utilities.inl
   include/bit/memory/detail/std_allocator_adapter.inl
+  include/bit/memory/detail/std_any_allocator_adapter.inl
   include/bit/memory/detail/unaligned_memory.inl
   include/bit/memory/detail/uninitialized_storage.inl
 

--- a/include/bit/memory/allocators/any_allocator.hpp
+++ b/include/bit/memory/allocators/any_allocator.hpp
@@ -191,7 +191,16 @@ namespace bit {
 
       void*        m_ptr;
       vtable_type* m_vtable;
+
+      friend bool operator==( const any_allocator&, const any_allocator& ) noexcept;
     };
+
+    //-------------------------------------------------------------------------
+    // Equality Comparison
+    //-------------------------------------------------------------------------
+
+    bool operator==( const any_allocator& lhs, const any_allocator& rhs ) noexcept;
+    bool operator!=( const any_allocator& lhs, const any_allocator& rhs ) noexcept;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/detail/any_allocator.inl
+++ b/include/bit/memory/allocators/detail/any_allocator.inl
@@ -53,4 +53,23 @@ inline bit::memory::allocator_info bit::memory::any_allocator::info()
   return m_vtable->info_fn( m_ptr );
 }
 
+//----------------------------------------------------------------------------
+// Equality Comparison
+//----------------------------------------------------------------------------
+
+inline bool bit::memory::operator==( const any_allocator& lhs,
+                                     const any_allocator& rhs )
+  noexcept
+{
+  return lhs.m_vtable == rhs.m_vtable &&
+         lhs.m_ptr == rhs.m_ptr;
+}
+
+inline bool bit::memory::operator!=( const any_allocator& lhs,
+                                     const any_allocator& rhs )
+  noexcept
+{
+  return !(lhs==rhs);
+}
+
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_ANY_ALLOCATOR_INL */

--- a/include/bit/memory/detail/std_any_allocator_adapter.inl
+++ b/include/bit/memory/detail/std_any_allocator_adapter.inl
@@ -1,0 +1,96 @@
+#ifndef BIT_MEMORY_DETAIL_STD_ANY_ALLOCATOR_ADAPTER_INL
+#define BIT_MEMORY_DETAIL_STD_ANY_ALLOCATOR_ADAPTER_INL
+
+//============================================================================
+// std_allocator_adapter
+//============================================================================
+
+//----------------------------------------------------------------------------
+// Constructors
+//----------------------------------------------------------------------------
+
+template<typename T>
+template<typename Allocator, typename>
+inline bit::memory::std_any_allocator_adapter<T>
+  ::std_any_allocator_adapter( Allocator& allocator )
+  noexcept
+  : m_allocator( allocator )
+{
+
+}
+
+template<typename T>
+template<typename U>
+inline bit::memory::std_any_allocator_adapter<T>
+  ::std_any_allocator_adapter( const std_any_allocator_adapter<U>& other )
+  noexcept
+  : m_allocator( other.get() )
+{
+
+}
+
+template<typename T>
+template<typename U>
+inline bit::memory::std_any_allocator_adapter<T>
+  ::std_any_allocator_adapter( std_any_allocator_adapter<U>&& other )
+  noexcept
+  : m_allocator( other.get() )
+{
+
+}
+
+//----------------------------------------------------------------------------
+// Allocation
+//----------------------------------------------------------------------------
+
+template<typename T>
+inline typename bit::memory::std_any_allocator_adapter<T>::pointer
+  bit::memory::std_any_allocator_adapter<T>
+  ::allocate( size_type n )
+{
+  auto p = m_allocator.try_allocate( sizeof(T) * n, alignof(T) );
+  return static_cast<pointer>(p);
+}
+
+template<typename T>
+inline void bit::memory::std_any_allocator_adapter<T>
+  ::deallocate( pointer p, size_type n )
+{
+  m_allocator.deallocate( static_cast<void_pointer>(p), sizeof(T) * n );
+}
+
+//----------------------------------------------------------------------------
+// Observers
+//----------------------------------------------------------------------------
+
+template<typename T>
+inline bit::memory::any_allocator
+  bit::memory::std_any_allocator_adapter<T>::get()
+  const noexcept
+{
+  return m_allocator;
+}
+
+//----------------------------------------------------------------------------
+// Equality Comparisons
+//----------------------------------------------------------------------------
+
+template<typename T, typename U>
+inline bool bit::memory
+  ::operator==( const std_any_allocator_adapter<T>& lhs,
+                const std_any_allocator_adapter<U>& rhs )
+  noexcept
+{
+  return lhs.get() == rhs.get();
+}
+
+template<typename T, typename U>
+inline bool bit::memory
+  ::operator!=( const std_any_allocator_adapter<T>& lhs,
+                const std_any_allocator_adapter<U>& rhs )
+  noexcept
+{
+  return !(lhs==rhs);
+}
+
+#endif /* BIT_MEMORY_DETAIL_STD_ANY_ALLOCATOR_ADAPTER_INL */

--- a/include/bit/memory/std_allocator_adapter.hpp
+++ b/include/bit/memory/std_allocator_adapter.hpp
@@ -25,14 +25,14 @@
 namespace bit {
   namespace memory {
 
-    //////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// \brief The adapter to make an Allocator behave like a standard
     ///        allocator
     ///
     /// \tparam T the underlying allocator type
     /// \tparam Allocator the underlying allocator that satisfies the
     ///         Allocator requirements
-    //////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     template<typename T, typename Allocator>
     class std_allocator_adapter
       : private detail::ebo_storage<allocator_reference<Allocator>>
@@ -44,9 +44,9 @@ namespace bit {
       static_assert( !std::is_const<T>::value, "Unable to allocate const type" );
       static_assert( is_allocator<Allocator>::value, "Allocator must satisfy Allocator requirements" );
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Public Member Types
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       using void_pointer       = typename traits_type::pointer;
@@ -64,9 +64,9 @@ namespace bit {
 
       using is_always_equal = typename traits_type::is_stateless;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Constructors
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Constructs a std_allocator_adapter that references the
@@ -97,9 +97,9 @@ namespace bit {
       template<typename U>
       std_allocator_adapter( std_allocator_adapter<U,Allocator>&& other ) noexcept;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Allocation
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Allocates memory using the underlying Allocator
@@ -114,9 +114,9 @@ namespace bit {
       /// \param n the number of entries to deallocate
       void deallocate( pointer p, size_type n );
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Observers
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
 
       /// \brief Gets the maximum size this allocator supports
       ///
@@ -130,9 +130,13 @@ namespace bit {
       Allocator& get() const noexcept;
     };
 
-    //------------------------------------------------------------------------
+    template<typename T, typename Allocator>
+    class std_allocator_adapter<T[],Allocator>
+      : public std_allocator_adapter<T,Allocator>{};
+
+    //-------------------------------------------------------------------------
     // Utilities
-    //------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
 
     /// \brief Makes an allocator adapter from a given allocator
     ///
@@ -142,9 +146,9 @@ namespace bit {
     std_allocator_adapter<T,Allocator>
       make_allocator_adapter( Allocator& allocator ) noexcept;
 
-    //------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
     // Equality Comparisons
-    //------------------------------------------------------------------------
+    //-------------------------------------------------------------------------
 
     template<typename T1, typename T2, typename Allocator>
     bool operator==( const std_allocator_adapter<T1,Allocator>& lhs,

--- a/include/bit/memory/std_any_allocator_adapter.hpp
+++ b/include/bit/memory/std_any_allocator_adapter.hpp
@@ -1,0 +1,140 @@
+/**
+ * \file std_any_allocator_adapter.hpp
+ *
+ * \brief A type-erased standard allocator adapter
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+#ifndef BIT_MEMORY_STD_ANY_ALLOCATOR_ADAPTER_HPP
+#define BIT_MEMORY_STD_ANY_ALLOCATOR_ADAPTER_HPP
+
+#include "allocators/any_allocator.hpp" // any_allocator
+
+#include <cstddef>     // std::size_t, std::ptrdiff_t
+#include <type_traits> // std::is_reference, std::is_const
+
+namespace bit {
+  namespace memory {
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief The adapter to make an Allocator behave like a standard
+    ///        allocator, while type-erasing the actual allocator
+    ///
+    /// \tparam T the underlying allocator type
+    ///////////////////////////////////////////////////////////////////////////
+    template<typename T>
+    class std_any_allocator_adapter
+    {
+      template<typename A>
+      using is_enabled = std::integral_constant<bool,
+        is_allocator<A>::value && !std::is_same<any_allocator,A>::value
+      >;
+
+      static_assert( !std::is_reference<T>::value, "Unable to allocate reference type" );
+      static_assert( !std::is_const<T>::value, "Unable to allocate const type" );
+
+      //-----------------------------------------------------------------------
+      // Public Member Types
+      //-----------------------------------------------------------------------
+    public:
+
+      using void_pointer       = void*;
+      using const_void_pointer = const void*;
+      using size_type          = std::size_t;
+      using difference_type    = std::ptrdiff_t;
+
+      using value_type      = T;
+      using pointer         = T*;
+      using const_pointer   = const T*;
+      using reference       = T&;
+      using const_reference = const T&;
+
+      template<typename U> struct rebind { using other = std_any_allocator_adapter<U>; };
+
+      //-----------------------------------------------------------------------
+      // Constructors
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Constructs a std_any_allocator_adapter that references the
+      ///        underlying allocator
+      ///
+      /// \param allocator the allocator to reference
+      template<typename Allocator, typename = std::enable_if_t<is_enabled<Allocator>::value>>
+      std_any_allocator_adapter( Allocator& allocator ) noexcept;
+
+      /// \brief Copy-constructs a std_any_allocator_adapter from an existing one
+      ///
+      /// \param other the other adapter to copy
+      std_any_allocator_adapter( const std_any_allocator_adapter& other ) = default;
+
+      /// \brief Move-constructs a std_any_allocator_adapter from an existing one
+      ///
+      /// \param other the other adapter to move
+      std_any_allocator_adapter( std_any_allocator_adapter&& other ) = default;
+
+      /// \brief Copy-converts a std_any_allocator_adapter from an existing one
+      ///
+      /// \param other the other adapter to copy-convert
+      template<typename U>
+      std_any_allocator_adapter( const std_any_allocator_adapter<U>& other ) noexcept;
+
+      /// \brief Move-converts a std_any_allocator_adapter from an existing one
+      ///
+      /// \param other the other adapter to move-convert
+      template<typename U>
+      std_any_allocator_adapter( std_any_allocator_adapter<U>&& other ) noexcept;
+
+      //-----------------------------------------------------------------------
+      // Allocation
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Allocates memory using the underlying allocator
+      ///
+      /// \param n the number of T entries to allocate
+      /// \return the pointer to T
+      pointer allocate( size_type n );
+
+      /// \brief Deallocates memory using the underlying allocator
+      ///
+      /// \param p the pointer to deallocate
+      /// \param n the number of entries to deallocate
+      void deallocate( pointer p, size_type n );
+
+      //-----------------------------------------------------------------------
+      // Observer
+      //-----------------------------------------------------------------------
+    public:
+
+      any_allocator get() const noexcept;
+
+      //-----------------------------------------------------------------------
+      // Private Members
+      //-----------------------------------------------------------------------
+    private:
+
+      any_allocator m_allocator;
+    };
+
+  template<typename T>
+  class std_any_allocator_adapter<T[]> : public std_any_allocator_adapter<T>{};
+
+  //-------------------------------------------------------------------------
+  // Equality Comparisons
+  //-------------------------------------------------------------------------
+
+  template<typename T, typename U>
+  bool operator==( const std_any_allocator_adapter<T>& lhs,
+                   const std_any_allocator_adapter<U>& rhs ) noexcept;
+
+  template<typename T, typename U>
+  bool operator!=( const std_any_allocator_adapter<T>& lhs,
+                   const std_any_allocator_adapter<U>& rhs ) noexcept;
+
+  } // namespace memory
+} // namespace bit
+
+#include "detail/std_any_allocator_adapter.inl"
+
+#endif /* BIT_MEMORY_STD_ANY_ALLOCATOR_ADAPTER_HPP */


### PR DESCRIPTION
Added `std_any_allocator_adapter`; an allocator adapter that always type-erases the underlying allocator.