### PR TITLE
Added default `info()` functions to all allocators

### DIFF
--- a/include/bit/memory/allocator_traits.hpp
+++ b/include/bit/memory/allocator_traits.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>     // std::size_t, std::ptrdiff_t
 #include <limits>      // std::numeric_limits
 #include <memory>      // std::addressof
+#include <typeinfo>    // std::type_info
 
 namespace bit {
   namespace memory {
@@ -163,7 +164,8 @@ namespace bit {
       /// \brief Gets the name of the specified allocator
       ///
       /// \note Not all allocators are nameable or have a name specified.
-      ///       For these allocators, the string returned is "Unnamed"
+      ///       For these allocators, the string returned is
+      ///       \c typeid(Allocator).name()
       ///
       /// \note The lifetime of the pointer returned is unmanaged, and is NOT
       ///       the responsibility of the caller to free.

--- a/include/bit/memory/allocators/aligned_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_allocator.hpp
@@ -9,9 +9,12 @@
 #ifndef BIT_MEMORY_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 
-#include "../owner.hpp"          // owner
-#include "../errors.hpp"         // out_of_memory_handler
+#include "detail/named_allocator.hpp" // detail::named_allocator
+
+#include "../allocator_info.hpp" // allocator_info
 #include "../aligned_memory.hpp" // aligned_malloc, aligned_free
+#include "../macros.hpp"         // BIT_MEMORY_UNUSED
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::max_align_t
 #include <type_traits> // std::true_type
@@ -78,23 +81,32 @@ namespace bit {
       ///
       /// \param size the size of this allocation
       /// \param align the requested alignment
-      /// \return the allocated pointer
-      owner<void*> allocate( std::size_t size, std::size_t align );
-
-      /// \brief Allocates aligned memory of size \p size, with alignment to a
-      ///        boundary of at least \p align
-      ///
-      /// \param size the size of this allocation
-      /// \param align the requested alignment
       /// \return the allocated pointer, or nullptr on failure
-      void* try_allocate( std::size_t size, std::size_t align ) noexcept;
+      owner<void*> try_allocate( std::size_t size, std::size_t align ) noexcept;
 
       /// \brief Deallocates a pointer \p p with the allocation size of \p size
       ///
       /// \param p the pointer to deallocate
       /// \param size the size to deallocate
       void deallocate( owner<void*> p, std::size_t size );
+
+      //---------------------------------------------------------------------
+      // Observers
+      //---------------------------------------------------------------------
+    public:
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'aligned_allocator'. Use a named_aligned_allocator
+      /// to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
+
+    //-------------------------------------------------------------------------
+    // Equality
+    //-------------------------------------------------------------------------
 
     /// \{
     /// \brief Compares equality between two aligned_allocator
@@ -105,6 +117,12 @@ namespace bit {
     bool operator!=( const aligned_allocator& lhs,
                      const aligned_allocator& rhs ) noexcept;
     /// \}
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    using named_aligned_allocator = detail::named_allocator<aligned_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/aligned_offset_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_offset_allocator.hpp
@@ -9,8 +9,12 @@
 #ifndef BIT_MEMORY_ALLOCATORS_ALIGNED_OFFSET_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_ALIGNED_OFFSET_ALLOCATOR_HPP
 
-#include "../owner.hpp"          // owner
+#include "detail/named_allocator.hpp" // detail::named_allocator
+
+#include "../allocator_info.hpp" // allocator_info
 #include "../aligned_memory.hpp" // aligned_malloc, aligned_free
+#include "../macros.hpp"         // BIT_MEMORY_UNUSED
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::max_align_t
 #include <type_traits> // std::true_type
@@ -79,16 +83,33 @@ namespace bit {
       /// \param align the requested alignment
       /// \param offset the offset to align to
       /// \return the allocated pointer, or nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align,
-                          std::size_t offset = 0 ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align,
+                                 std::size_t offset = 0 ) noexcept;
 
       /// \brief Deallocates a pointer \p p with the allocation size of \p size
       ///
       /// \param p the pointer to deallocate
       /// \param size the size to deallocate
       void deallocate( owner<void*> p, std::size_t size );
+
+      //---------------------------------------------------------------------
+      // Observers
+      //---------------------------------------------------------------------
+    public:
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'aligned_offset_allocator'. Use a
+      /// named_aligned_offset_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
+
+    //-------------------------------------------------------------------------
+    // Equality
+    //-------------------------------------------------------------------------
 
     /// \{
     /// \brief Compares equality between two aligned_allocator
@@ -99,6 +120,12 @@ namespace bit {
     bool operator!=( const aligned_offset_allocator& lhs,
                      const aligned_offset_allocator& rhs ) noexcept;
     /// \}
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    using named_aligned_allocator = detail::named_allocator<aligned_offset_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/bump_down_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_allocator.hpp
@@ -13,6 +13,7 @@
 
 #include "../macros.hpp"            // BIT_MEMORY_UNLIKELY
 #include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
 #include "../pointer_utilities.hpp" // offset_align_backward
 
 #include <cassert>     // assert
@@ -89,15 +90,15 @@ namespace bit {
       /// \param align the requested alignment of the allocation
       /// \param offset the amount to offset the alignment by
       /// \return the allocated pointer on success, \c nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align,
-                          std::size_t offset = 0 ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align,
+                                 std::size_t offset = 0 ) noexcept;
 
       /// \brief Does nothing for linear_allocator. Use deallocate_all
       ///
       /// \param p the pointer
       /// \param size the size of the allocation
-      void deallocate( void* p, std::size_t size );
+      void deallocate( owner<void*> p, std::size_t size );
 
       /// \brief Deallocates everything from this allocator
       void deallocate_all() noexcept;
@@ -112,6 +113,14 @@ namespace bit {
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
       bool owns( const void* p ) const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'bump_down_allocator'. Use a
+      /// named_bump_down_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
@@ -14,6 +14,7 @@
 
 #include "../macros.hpp"            // BIT_MEMORY_UNLIKELY
 #include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
 #include "../pointer_utilities.hpp" // offset_align_backward
 
 #include <cassert>     // assert
@@ -93,15 +94,15 @@ namespace bit {
       /// \param align the requested alignment of the allocation
       /// \param offset the amount to offset the alignment by
       /// \return the allocated pointer on success, \c nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align,
-                          std::size_t offset = 0 ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align,
+                                 std::size_t offset = 0 ) noexcept;
 
       /// \brief Does nothing for linear_allocator. Use deallocate_all
       ///
       /// \param p the pointer
       /// \param size the size of the allocation
-      void deallocate( void* p, std::size_t size );
+      void deallocate( owner<void*> p, std::size_t size );
 
       /// \brief Deallocates everything from this allocator
       void deallocate_all() noexcept;
@@ -116,6 +117,14 @@ namespace bit {
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
       bool owns( const void* p ) const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'bump_down_lifo_allocator'. Use a
+      /// named_bump_down_lifo_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/bump_up_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_allocator.hpp
@@ -13,6 +13,7 @@
 
 #include "../macros.hpp"            // BIT_MEMORY_UNLIKELY
 #include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
 #include "../pointer_utilities.hpp" // offset_align_forward
 
 #include <cassert>     // assert
@@ -81,15 +82,15 @@ namespace bit {
       /// \param align the requested alignment of the allocation
       /// \param offset the amount to offset the alignment by
       /// \return the allocated pointer on success, \c nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align,
-                          std::size_t offset = 0 ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align,
+                                 std::size_t offset = 0 ) noexcept;
 
       /// \brief Does nothing for bump_up_allocator. Use deallocate_all
       ///
       /// \param p the pointer
       /// \param size the size of the allocation
-      void deallocate( void* p, std::size_t size );
+      void deallocate( owner<void*> p, std::size_t size );
 
       /// \brief Deallocates everything from this allocator
       void deallocate_all() noexcept;
@@ -104,6 +105,14 @@ namespace bit {
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
       bool owns( const void* p ) const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'bump_up_allocator'. Use a
+      /// named_bump_up_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
@@ -14,6 +14,7 @@
 
 #include "../macros.hpp"            // BIT_MEMORY_UNLIKELY
 #include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
 #include "../pointer_utilities.hpp" // offset_align_forward
 
 #include <cassert>     // assert
@@ -93,15 +94,15 @@ namespace bit {
       /// \param align the requested alignment of the allocation
       /// \param offset the amount to offset the alignment by
       /// \return the allocated pointer on success, \c nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align,
-                          std::size_t offset = 0 ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align,
+                                 std::size_t offset = 0 ) noexcept;
 
       /// \brief Does nothing for bump_up_lifo_allocator. Use deallocate_all
       ///
       /// \param p the pointer
       /// \param size the size of the allocation
-      void deallocate( void* p, std::size_t size );
+      void deallocate( owner<void*> p, std::size_t size );
 
       /// \brief Deallocates everything from this allocator
       void deallocate_all() noexcept;
@@ -116,6 +117,14 @@ namespace bit {
       /// \param p the pointer to check
       /// \return \c true if \p p is contained in this allocator
       bool owns( const void* p ) const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'bump_up_lifo_allocator'. Use a
+      /// named_bump_up_lifo_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/allocators/detail/aligned_allocator.inl
+++ b/include/bit/memory/allocators/detail/aligned_allocator.inl
@@ -6,20 +6,8 @@
 //-----------------------------------------------------------------------------
 
 inline bit::memory::owner<void*>
-  bit::memory::aligned_allocator::allocate( std::size_t size,
-                                            std::size_t align )
-{
-  auto p = try_allocate( size, align );
-
-  if( p == nullptr ) {
-    get_out_of_memory_handler()({"aligned_allocator",nullptr},size);
-  }
-
-  return p;
-}
-
-inline void* bit::memory::aligned_allocator::try_allocate( std::size_t size,
-                                                           std::size_t align )
+  bit::memory::aligned_allocator::try_allocate( std::size_t size,
+                                                std::size_t align )
   noexcept
 {
   return aligned_malloc( size, align );
@@ -28,12 +16,23 @@ inline void* bit::memory::aligned_allocator::try_allocate( std::size_t size,
 inline void bit::memory::aligned_allocator::deallocate( owner<void*> p,
                                                         std::size_t size )
 {
-  (void) size;
+  BIT_MEMORY_UNUSED(size);
+
   aligned_free( p );
 }
 
 //-----------------------------------------------------------------------------
-// Comparators
+// Observers
+//-----------------------------------------------------------------------------
+
+inline bit::memory::allocator_info bit::memory::aligned_allocator::info()
+  const noexcept
+{
+  return {"aligned_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Equality
 //-----------------------------------------------------------------------------
 
 inline bool bit::memory::operator==( const aligned_allocator&,

--- a/include/bit/memory/allocators/detail/aligned_offset_allocator.inl
+++ b/include/bit/memory/allocators/detail/aligned_offset_allocator.inl
@@ -5,10 +5,10 @@
 // Allocations / Deallocation
 //-----------------------------------------------------------------------------
 
-inline void* bit::memory::aligned_offset_allocator
-  ::try_allocate( std::size_t size,
-                  std::size_t align,
-                  std::size_t offset )
+inline bit::memory::owner<void*>
+  bit::memory::aligned_offset_allocator::try_allocate( std::size_t size,
+                                                       std::size_t align,
+                                                       std::size_t offset )
   noexcept
 {
   return aligned_offset_malloc( size, align, offset );
@@ -18,8 +18,18 @@ inline void bit::memory::aligned_offset_allocator
   ::deallocate( owner<void*> p,
                 std::size_t size )
 {
-  (void) size;
+  BIT_MEMORY_UNUSED(size);
   aligned_offset_free( p );
+}
+
+//-----------------------------------------------------------------------------
+// Observers
+//-----------------------------------------------------------------------------
+
+inline bit::memory::allocator_info bit::memory::aligned_offset_allocator::info()
+  const noexcept
+{
+  return {"aligned_offset_allocator",nullptr};
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/allocators/detail/bump_down_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_down_allocator.inl
@@ -21,9 +21,10 @@ inline bit::memory::bump_down_allocator::bump_down_allocator( memory_block block
 // Allocation / Deallocation
 //----------------------------------------------------------------------------
 
-inline void* bit::memory::bump_down_allocator::try_allocate( std::size_t size,
-                                                             std::size_t align,
-                                                             std::size_t offset )
+inline bit::memory::owner<void*>
+  bit::memory::bump_down_allocator::try_allocate( std::size_t size,
+                                                  std::size_t align,
+                                                  std::size_t offset )
   noexcept
 {
   assert( size && "cannot allocate 0 bytes");
@@ -46,7 +47,7 @@ inline void* bit::memory::bump_down_allocator::try_allocate( std::size_t size,
 
 //----------------------------------------------------------------------------
 
-inline void bit::memory::bump_down_allocator::deallocate( void* p,
+inline void bit::memory::bump_down_allocator::deallocate( owner<void*> p,
                                                           std::size_t size )
 {
   BIT_MEMORY_UNUSED(p);
@@ -71,6 +72,12 @@ inline bool bit::memory::bump_down_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;
+}
+
+inline bit::memory::allocator_info bit::memory::bump_down_allocator::info()
+  const noexcept
+{
+  return {"bump_down_allocator",this};
 }
 
 //----------------------------------------------------------------------------

--- a/include/bit/memory/allocators/detail/bump_down_lifo_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_down_lifo_allocator.inl
@@ -21,10 +21,10 @@ inline bit::memory::bump_down_lifo_allocator::bump_down_lifo_allocator( memory_b
 // Allocation / Deallocation
 //----------------------------------------------------------------------------
 
-inline void* bit::memory::bump_down_lifo_allocator
-  ::try_allocate( std::size_t size,
-                  std::size_t align,
-                  std::size_t offset )
+inline bit::memory::owner<void*>
+  bit::memory::bump_down_lifo_allocator::try_allocate( std::size_t size,
+                                                       std::size_t align,
+                                                       std::size_t offset )
   noexcept
 {
   assert( size && "cannot allocate 0 bytes");
@@ -54,7 +54,7 @@ inline void* bit::memory::bump_down_lifo_allocator
 //----------------------------------------------------------------------------
 
 inline void bit::memory::bump_down_lifo_allocator
-  ::deallocate( void* p, std::size_t size )
+  ::deallocate( owner<void*> p, std::size_t size )
 {
   BIT_MEMORY_UNUSED(size);
 
@@ -89,6 +89,12 @@ inline bool bit::memory::bump_down_lifo_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;
+}
+
+inline bit::memory::allocator_info bit::memory::bump_down_lifo_allocator::info()
+  const noexcept
+{
+  return {"bump_down_lifo_allocator",this};
 }
 
 //----------------------------------------------------------------------------

--- a/include/bit/memory/allocators/detail/bump_up_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_up_allocator.inl
@@ -21,9 +21,10 @@ inline bit::memory::bump_up_allocator::bump_up_allocator( memory_block block )
 // Allocation / Deallocation
 //----------------------------------------------------------------------------
 
-inline void* bit::memory::bump_up_allocator::try_allocate( std::size_t size,
-                                                           std::size_t align,
-                                                           std::size_t offset )
+inline bit::memory::owner<void*>
+  bit::memory::bump_up_allocator::try_allocate( std::size_t size,
+                                                std::size_t align,
+                                                std::size_t offset )
   noexcept
 {
   assert( size && "cannot allocate 0 bytes");
@@ -48,7 +49,7 @@ inline void* bit::memory::bump_up_allocator::try_allocate( std::size_t size,
 
 //----------------------------------------------------------------------------
 
-inline void bit::memory::bump_up_allocator::deallocate( void* p,
+inline void bit::memory::bump_up_allocator::deallocate( owner<void*> p,
                                                         std::size_t size )
 {
   BIT_MEMORY_UNUSED(p);
@@ -75,6 +76,12 @@ inline bool bit::memory::bump_up_allocator::owns( const void* p )
   const noexcept
 {
   return m_block.start_address() <= p && p < m_current;
+}
+
+inline bit::memory::allocator_info bit::memory::bump_up_allocator::info()
+  const noexcept
+{
+  return {"bump_up_allocator",this};
 }
 
 //----------------------------------------------------------------------------

--- a/include/bit/memory/allocators/detail/bump_up_lifo_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_up_lifo_allocator.inl
@@ -90,6 +90,12 @@ inline bool bit::memory::bump_up_lifo_allocator::owns( const void* p )
   return m_block.start_address() <= p && p < m_current;
 }
 
+inline bit::memory::allocator_info bit::memory::bump_up_lifo_allocator::info()
+  const noexcept
+{
+  return {"bump_up_lifo_allocator",this};
+}
+
 //----------------------------------------------------------------------------
 // Comparisons
 //----------------------------------------------------------------------------

--- a/include/bit/memory/allocators/detail/fallback_allocator.inl
+++ b/include/bit/memory/allocators/detail/fallback_allocator.inl
@@ -21,9 +21,9 @@ bit::memory::fallback_allocator<Allocators...>
 }
 
 template<typename...Allocators>
-void* bit::memory::fallback_allocator<Allocators...>
-  ::try_allocate( std::size_t size,
-                  std::size_t align )
+bit::memory::owner<void*>
+  bit::memory::fallback_allocator<Allocators...>::try_allocate( std::size_t size,
+                                                                std::size_t align )
   noexcept
 {
   return do_try_allocate( std::integral_constant<std::size_t,0>{}, size, align );
@@ -32,7 +32,7 @@ void* bit::memory::fallback_allocator<Allocators...>
 
 template<typename...Allocators>
 void bit::memory::fallback_allocator<Allocators...>
-  ::deallocate( void* p, std::size_t size )
+  ::deallocate( owner<void*> p, std::size_t size )
 {
   do_deallocate( std::integral_constant<std::size_t,0>{}, p, size );
 }

--- a/include/bit/memory/allocators/detail/malloc_allocator.inl
+++ b/include/bit/memory/allocators/detail/malloc_allocator.inl
@@ -6,24 +6,11 @@
 //-----------------------------------------------------------------------------
 
 inline bit::memory::owner<void*>
-  bit::memory::malloc_allocator::allocate( std::size_t size,
-                                           std::size_t align )
-{
-  auto p = try_allocate(size,align);
-
-  if( p == nullptr ) {
-    get_out_of_memory_handler()( {"malloc_allocator", nullptr}, size );
-  }
-
-  return p;
-}
-
-inline bit::memory::owner<void*>
   bit::memory::malloc_allocator::try_allocate( std::size_t size,
                                                std::size_t align )
   noexcept
 {
-  (void) align;
+  BIT_MEMORY_UNUSED(align);
 
   return std::malloc( size );
 }
@@ -33,13 +20,23 @@ inline bit::memory::owner<void*>
 inline void bit::memory::malloc_allocator::deallocate( owner<void*> p,
                                                        std::size_t size )
 {
-  (void) size;
+  BIT_MEMORY_UNUSED(size);
 
   std::free( p );
 }
 
 //-----------------------------------------------------------------------------
-// Comparisons
+// Observers
+//-----------------------------------------------------------------------------
+
+inline bit::memory::allocator_info bit::memory::malloc_allocator::info()
+  const noexcept
+{
+  return {"malloc_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Equality
 //-----------------------------------------------------------------------------
 
 inline bool bit::memory::operator==( const malloc_allocator&,

--- a/include/bit/memory/allocators/detail/min_aligned_allocator.inl
+++ b/include/bit/memory/allocators/detail/min_aligned_allocator.inl
@@ -67,23 +67,13 @@ inline void bit::memory::min_aligned_allocator<Allocator,MinAlign>
 //-----------------------------------------------------------------------------
 
 template<typename Allocator, std::size_t MinAlign>
-inline const char* bit::memory::min_aligned_allocator<Allocator,MinAlign>
-  ::name()
+inline bit::memory::allocator_info
+  bit::memory::min_aligned_allocator<Allocator,MinAlign>::info()
   const noexcept
 {
   auto& allocator = detail::get<0>( *this );
 
-  return traits_type::name( allocator );
-}
-
-template<typename Allocator, std::size_t MinAlign>
-inline void bit::memory::min_aligned_allocator<Allocator,MinAlign>
-  ::set_name( const char* name )
-  noexcept
-{
-  auto& allocator = detail::get<0>( *this );
-
-  return traits_type::set_name( allocator, name );
+  return traits_type::info( allocator );
 }
 
 //-----------------------------------------------------------------------------
@@ -102,16 +92,16 @@ inline std::size_t bit::memory::min_aligned_allocator<Allocator,MinAlign>
 
 template<typename Allocator, std::size_t MinAlign>
 inline std::size_t bit::memory::min_aligned_allocator<Allocator,MinAlign>
-  ::used()
+  ::min_size()
   const noexcept
 {
   auto& allocator = detail::get<0>( *this );
 
-  return traits_type::used( allocator );
+  return traits_type::min_size( allocator );
 }
 
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
 template<typename Allocator, std::size_t MinAlign>

--- a/include/bit/memory/allocators/detail/new_allocator.inl
+++ b/include/bit/memory/allocators/detail/new_allocator.inl
@@ -2,23 +2,11 @@
 #define BIT_MEMORY_ALLOCATORS_DETAIL_NEW_ALLOCATOR_INL
 
 inline bit::memory::owner<void*>
-  bit::memory::new_allocator::allocate( std::size_t size,
-                                        std::size_t align )
-{
-  auto p = try_allocate( size, align );
-
-  if( p == nullptr ) {
-    get_out_of_memory_handler()({"new_allocator",nullptr},size);
-  }
-  return p;
-}
-
-inline bit::memory::owner<void*>
   bit::memory::new_allocator::try_allocate( std::size_t size,
                                             std::size_t align )
   noexcept
 {
-  (void) align;
+  BIT_MEMORY_UNUSED(align);
 
   return ::operator new( size, std::nothrow );
 }
@@ -26,13 +14,24 @@ inline bit::memory::owner<void*>
 inline void bit::memory::new_allocator::deallocate( owner<void*> p,
                                                     std::size_t size )
 {
-  (void) size;
+  BIT_MEMORY_UNUSED(size);
 
   ::operator delete(p);
 }
 
+
 //-----------------------------------------------------------------------------
-// Comparisons
+// Observers
+//-----------------------------------------------------------------------------
+
+inline bit::memory::allocator_info bit::memory::new_allocator::info()
+  const noexcept
+{
+  return {"new_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Equality
 //-----------------------------------------------------------------------------
 
 inline bool bit::memory::operator==( const new_allocator&,

--- a/include/bit/memory/allocators/detail/null_allocator.inl
+++ b/include/bit/memory/allocators/detail/null_allocator.inl
@@ -1,13 +1,13 @@
 #ifndef BIT_MEMORY_ALLOCATORS_DETAIL_NULL_ALLOCATOR_INL
 #define BIT_MEMORY_ALLOCATORS_DETAIL_NULL_ALLOCATOR_INL
 
-//============================================================================
+//=============================================================================
 // null_allocator
-//============================================================================
+//=============================================================================
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Allocation
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline bit::memory::owner<void*>
   bit::memory::null_allocator::try_allocate( std::size_t size,
@@ -15,9 +15,9 @@ inline bit::memory::owner<void*>
                                              std::size_t offset )
   noexcept
 {
-  (void) size;
-  (void) align;
-  (void) offset;
+  BIT_MEMORY_UNUSED(size);
+  BIT_MEMORY_UNUSED(align);
+  BIT_MEMORY_UNUSED(offset);
 
   return nullptr;
 }
@@ -27,13 +27,13 @@ inline void bit::memory::null_allocator::deallocate( owner<void*> p,
                                                      std::size_t size )
   noexcept
 {
-  (void) p;
-  (void) size;
+  BIT_MEMORY_UNUSED(p);
+  BIT_MEMORY_UNUSED(size);
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Observers
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline bool bit::memory::null_allocator::owns( const void* p )
   const noexcept
@@ -47,9 +47,17 @@ inline bool bit::memory::null_allocator::owns( std::nullptr_t )
   return true;
 }
 
-//----------------------------------------------------------------------------
-// Comparisons
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+
+inline bit::memory::allocator_info bit::memory::null_allocator::info()
+  const noexcept
+{
+  return {"null_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Equality
+//-----------------------------------------------------------------------------
 
 inline bool bit::memory::operator==( const null_allocator&,
                                      const null_allocator& )

--- a/include/bit/memory/allocators/detail/pool_allocator.inl
+++ b/include/bit/memory/allocators/detail/pool_allocator.inl
@@ -33,9 +33,10 @@ inline bit::memory::pool_allocator::pool_allocator( std::size_t chunk_size,
 // Allocation / Deallocation
 //-----------------------------------------------------------------------------
 
-inline void* bit::memory::pool_allocator::try_allocate( std::size_t size,
-                                                        std::size_t align,
-                                                        std::size_t offset )
+inline bit::memory::owner<void*>
+  bit::memory::pool_allocator::try_allocate( std::size_t size,
+                                             std::size_t align,
+                                             std::size_t offset )
   noexcept
 {
   using byte_t = unsigned char;
@@ -54,7 +55,8 @@ inline void* bit::memory::pool_allocator::try_allocate( std::size_t size,
   return static_cast<char*>(p) + 1;
 }
 
-inline void bit::memory::pool_allocator::deallocate( void* p, std::size_t size )
+inline void bit::memory::pool_allocator::deallocate( owner<void*> p,
+                                                     std::size_t size )
 {
   BIT_MEMORY_UNUSED(size);
 
@@ -81,6 +83,14 @@ inline std::size_t bit::memory::pool_allocator::max_size()
   const noexcept
 {
   return m_chunk_size;
+}
+
+//-----------------------------------------------------------------------------
+
+inline bit::memory::allocator_info bit::memory::pool_allocator::info()
+  const noexcept
+{
+  return {"pool_allocator",this};
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/allocators/detail/stack_allocator.inl
+++ b/include/bit/memory/allocators/detail/stack_allocator.inl
@@ -20,7 +20,7 @@ inline bit::memory::stack_allocator<Size,Align>::~stack_allocator()
 {
   // This destructor should be trivial -- but instead calls
   // 'deallocate_all' so that the memory trackers can accurately reflect
-  // that the memory has accurately been deallocated on destruction
+  // that the memory has been deallocated on destruction
   deallocate_all();
 }
 
@@ -98,8 +98,15 @@ inline bool bit::memory::stack_allocator<Size,Align>::owns( const void* p )
   return static_cast<const void*>(&m_storage[0]) <= p && p < static_cast<const void*>(&m_storage[Size]);
 }
 
+template<std::size_t Size, std::size_t Align>
+inline bit::memory::allocator_info bit::memory::stack_allocator<Size,Align>::info()
+  const noexcept
+{
+  return {"stack_allocator",this};
+}
+
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
 template<std::size_t S, std::size_t A>

--- a/include/bit/memory/allocators/fallback_allocator.hpp
+++ b/include/bit/memory/allocators/fallback_allocator.hpp
@@ -9,12 +9,13 @@
 #ifndef BIT_MEMORY_ALLOCATORS_FALLBACK_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_FALLBACK_ALLOCATOR_HPP
 
-#include "../detail/ebo_storage.hpp" // detail::ebo_storage
+#include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../concepts/Allocator.hpp" // allocator_pointer_t, etc
-
-#include "../macros.hpp"           // BIT_MEMORY_UNUSED
-#include "../allocator_traits.hpp" // allocator_traits
+#include "../detail/ebo_storage.hpp" // detail::ebo_storage
+#include "../allocator_traits.hpp"   // allocator_traits
+#include "../macros.hpp"             // BIT_MEMORY_UNUSED
+#include "../owner.hpp"              // owner
 
 #include <tuple>     // std::forward_as_tuple
 #include <utility>   // std::forward
@@ -124,8 +125,8 @@ namespace bit {
       /// \param size the size of the allocation request
       /// \param align the alignment of the allocation request
       /// \return a pointer on success, \c nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align ) noexcept;
 
       /// \brief Deallocates the pointer \p p of size \p size from the
       ///        underlying allocator
@@ -137,7 +138,7 @@ namespace bit {
       ///
       /// \param p the pointer to memory to deallocate
       /// \param size the size of the memory to deallocate
-      void deallocate( void* p, std::size_t size );
+      void deallocate( owner<void*> p, std::size_t size );
 
       //-----------------------------------------------------------------------
       // Observers
@@ -208,6 +209,13 @@ namespace bit {
       std::size_t do_min_size( std::index_sequence<Idxs...> ) const noexcept;
 
     };
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    template<typename...Allocators>
+    using named_fallback_allocator = detail::named_allocator<fallback_allocator<Allocators...>>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/malloc_allocator.hpp
+++ b/include/bit/memory/allocators/malloc_allocator.hpp
@@ -9,8 +9,11 @@
 #ifndef BIT_MEMORY_ALLOCATORS_MALLOC_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_MALLOC_ALLOCATOR_HPP
 
-#include "../owner.hpp"  // owner
-#include "../errors.hpp" // out_of_memory_handler
+#include "detail/named_allocator.hpp" // detail::named_allocator
+
+#include "../allocator_info.hpp" // allocator_info
+#include "../owner.hpp"          // owner
+#include "../macros.hpp"         // BIT_MEMORY_UNUSED
 
 #include <cstdlib>     // std::malloc, std::free, std::size_t
 #include <cstddef>     // std::max_align_t
@@ -35,7 +38,7 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      using is_stateless    = std::true_type;
+      using is_stateless      = std::true_type;
       using default_alignment = std::integral_constant<std::size_t,alignof(std::max_align_t)>;
 
       //-----------------------------------------------------------------------
@@ -75,16 +78,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      /// \brief Allocates memory of size \p size
-      ///
-      /// The alignment is ignored for calls to this allocator. The alignment
-      /// is always guaranteed to be at least \c alignof(std::max_align_t)
-      ///
-      /// \param size the size of this allocation
-      /// \param align the requested alignment (ignored)
-      /// \return the allocated pointer
-      owner<void*> allocate( std::size_t size, std::size_t align );
-
       /// \brief Attempts to allocate memory of size \p size, returning nullptr
       ///        on failure
       ///
@@ -101,7 +94,24 @@ namespace bit {
       /// \param p the pointer to deallocate
       /// \param size the size to deallocate
       void deallocate( owner<void*> p, std::size_t size );
+
+      //-----------------------------------------------------------------------
+      // Observers
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'malloc_allocator'. Use a
+      /// named_malloc_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
+
+    //-------------------------------------------------------------------------
+    // Equality
+    //-------------------------------------------------------------------------
 
     /// \{
     /// \brief Compares equality between two malloc_allocators
@@ -112,6 +122,12 @@ namespace bit {
     bool operator!=( const malloc_allocator& lhs,
                      const malloc_allocator& rhs ) noexcept;
     /// \}
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    using named_malloc_allocator = detail::named_allocator<malloc_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/min_aligned_allocator.hpp
+++ b/include/bit/memory/allocators/min_aligned_allocator.hpp
@@ -114,7 +114,7 @@ namespace bit {
     /// \param size the size of this allocation
     /// \param align the requested alignment
     /// \return the allocated pointer, or nullptr on failure
-    void* try_allocate( std::size_t size, std::size_t align ) noexcept;
+    owner<void*> try_allocate( std::size_t size, std::size_t align ) noexcept;
 
     /// \brief Deallocates a pointer \p p with the allocation size of \p size
     ///
@@ -130,12 +130,7 @@ namespace bit {
     /// \brief Gets the name of the underlying allocator
     ///
     /// \return the name of the underlying allocator
-    const char* name() const noexcept;
-
-    /// \brief Sets the name of the underlying allocator
-    ///
-    /// \param name the name to set to the underlying allocator
-    void set_name( const char* name ) noexcept;
+    allocator_info info() const noexcept;
 
     //-----------------------------------------------------------------------
     // Capacity
@@ -151,16 +146,15 @@ namespace bit {
     ///        used
     ///
     /// \return the number of bytes used
-    std::size_t used() const noexcept;
+    std::size_t min_size() const noexcept;
 
     //-----------------------------------------------------------------------
-    // Comparators
+    // Equality
     //-----------------------------------------------------------------------
   public:
 
     bool operator==( const min_aligned_allocator& rhs ) const noexcept;
     bool operator!=( const min_aligned_allocator& rhs ) const noexcept;
-
   };
 
   } // namespace memory

--- a/include/bit/memory/allocators/new_allocator.hpp
+++ b/include/bit/memory/allocators/new_allocator.hpp
@@ -9,8 +9,11 @@
 #ifndef BIT_MEMORY_ALLOCATORS_NEW_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_NEW_ALLOCATOR_HPP
 
-#include "../owner.hpp"  // owner
-#include "../errors.hpp" // out_of_memory_handler
+#include "detail/named_allocator.hpp" // detail::named_allocator
+
+#include "../allocator_info.hpp" // allocator_info
+#include "../macros.hpp"         // BIT_MEMORY_UNUSED
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::size_t, std::max_align_t
 #include <new>         // ::operator new, ::operator delete, std::nothrow
@@ -75,16 +78,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      /// \brief Allocates memory of size \p size
-      ///
-      /// The alignment is ignored for calls to this allocator. The alignment
-      /// is always guaranteed to be at least \c alignof(std::max_align_t)
-      ///
-      /// \param size the size of this allocation
-      /// \param align the requested alignment (ignored)
-      /// \return the allocated pointer
-      owner<void*> allocate( std::size_t size, std::size_t align );
-
       /// \brief Attempts to allocate memory of size \p size, returning nullptr
       ///        on failure
       ///
@@ -101,7 +94,24 @@ namespace bit {
       /// \param p the pointer to deallocate
       /// \param size the size to deallocate
       void deallocate( owner<void*> p, std::size_t size );
+
+      //-----------------------------------------------------------------------
+      // Observers
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'malloc_allocator'. Use a
+      /// named_malloc_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
+
+    //-------------------------------------------------------------------------
+    // Equality
+    //-------------------------------------------------------------------------
 
     /// \{
     /// \brief Compares equality between two new_allocators
@@ -110,6 +120,12 @@ namespace bit {
     bool operator==( const new_allocator&, const new_allocator& ) noexcept;
     bool operator!=( const new_allocator&, const new_allocator& ) noexcept;
     /// \}
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    using named_new_allocator = detail::named_allocator<new_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/null_allocator.hpp
+++ b/include/bit/memory/allocators/null_allocator.hpp
@@ -8,8 +8,11 @@
 #ifndef BIT_MEMORY_ALLOCATORS_NULL_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_NULL_ALLOCATOR_HPP
 
-#include "../owner.hpp"  // owner
-#include "../errors.hpp" // out_of_memory_handler
+#include "detail/named_allocator.hpp" // detail::named_allocator
+
+#include "../allocator_info.hpp" // allocator_info
+#include "../macros.hpp"         // BIT_MEMORY_UNUSED
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::size_t
 #include <type_traits> // std::true_type
@@ -109,8 +112,20 @@ namespace bit {
       /// \return true
       bool owns( std::nullptr_t ) const noexcept;
 
+      //----------------------------------------------------------------------
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'null_allocator'. Use a
+      /// named_null_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
 
+    //-------------------------------------------------------------------------
+    // Equality
+    //-------------------------------------------------------------------------
 
     /// \{
     /// \brief Compares equality between two null_allocators
@@ -121,6 +136,12 @@ namespace bit {
     bool operator!=( const null_allocator& lhs,
                      const null_allocator& rhs ) noexcept;
     /// \}
+
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    using named_null_allocator = detail::named_allocator<null_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/pool_allocator.hpp
+++ b/include/bit/memory/allocators/pool_allocator.hpp
@@ -14,6 +14,7 @@
 #include "../freelist.hpp"          // freelist
 #include "../macros.hpp"            // BIT_MEMORY_ASSUME
 #include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
 #include "../pointer_utilities.hpp" // is_power_of_two
 
 #include <cassert>

--- a/include/bit/memory/allocators/pool_allocator.hpp
+++ b/include/bit/memory/allocators/pool_allocator.hpp
@@ -80,16 +80,16 @@ namespace bit {
       /// \param align the requested alignment of the allocation
       /// \param offset the amount to offset the alignment
       /// \return pointer to the allocated memory, or \c nullptr on failure
-      void* try_allocate( std::size_t size,
-                          std::size_t align,
-                          std::size_t offset = 0 ) noexcept;
+      owner<void*> try_allocate( std::size_t size,
+                                 std::size_t align,
+                                 std::size_t offset = 0 ) noexcept;
 
       /// \brief Deallocates memory previously allocated from a call to
       ///        \c try_allocate
       ///
       /// \param p the pointer to the memory to deallocate
       /// \param size the size of the memory previously provided to try_allocate
-      void deallocate( void* p, std::size_t size );
+      void deallocate( owner<void*> p, std::size_t size );
 
       //-----------------------------------------------------------------------
       // Observers
@@ -105,6 +105,16 @@ namespace bit {
       ///
       /// \return the max size
       std::size_t max_size() const noexcept;
+
+      //----------------------------------------------------------------------
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'pool_allocator'. Use a
+      /// named_pool_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members
@@ -124,7 +134,7 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Comparison
+    // Equality
     //-------------------------------------------------------------------------
 
     bool operator==( const pool_allocator& lhs, const pool_allocator& rhs ) noexcept;

--- a/include/bit/memory/allocators/stack_allocator.hpp
+++ b/include/bit/memory/allocators/stack_allocator.hpp
@@ -110,6 +110,14 @@ namespace bit {
       /// \return \c true if \p p is contained in this allocator
       bool owns( const void* p ) const noexcept;
 
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'stack_allocator'. Use a
+      /// named_stack_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
+
       //-----------------------------------------------------------------------
       // Private Members
       //-----------------------------------------------------------------------
@@ -123,7 +131,7 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Comparison
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t S, std::size_t A>

--- a/include/bit/memory/block_allocator_traits.hpp
+++ b/include/bit/memory/block_allocator_traits.hpp
@@ -24,6 +24,7 @@
 #include <type_traits> // std::true_type, std::false_type, etc
 #include <cstddef>     // std::size_t, std::ptrdiff_t
 #include <memory>      // std::addressof
+#include <typeinfo>    // std::type_info
 
 namespace bit {
   namespace memory {
@@ -83,7 +84,8 @@ namespace bit {
       /// \brief Gets the name of the specified block allocator
       ///
       /// \note Not all allocators are nameable or have a name specified.
-      ///       For these allocators, the string returned is "Unnamed"
+      ///       For these allocators, the string returned is
+      ///       \c typeid(BlockAllocator).name()
       ///
       /// \note The lifetime of the pointer returned is unmanaged, and is NOT
       ///       the responsibility of the caller to free.

--- a/include/bit/memory/block_allocators/aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/aligned_block_allocator.hpp
@@ -11,12 +11,13 @@
 
 #include "detail/cached_block_allocator.hpp" // cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
-#include "../detail/dynamic_size_type.hpp"   // dynamic_size, detail::dynamic_size_type
 
-#include "../owner.hpp"             // owner
-#include "../memory_block.hpp"      // memory_block
-#include "../pointer_utilities.hpp" // is_power_of_two
+#include "../detail/dynamic_size_type.hpp" // dynamic_size, detail::dynamic_size_type
 #include "../aligned_memory.hpp"    // aligned_allocate
+#include "../allocator_info.hpp"    // allocator_info
+#include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
+#include "../pointer_utilities.hpp" // is_power_of_two
 
 #include <type_traits> // std::true_type, std::false_type, etc
 #include <cstddef>     // std::size_t
@@ -186,10 +187,18 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'aligned_block_allocator'.
+      /// Use a named_aligned_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t Size, std::size_t Align>

--- a/include/bit/memory/block_allocators/detail/aligned_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/aligned_block_allocator.inl
@@ -46,8 +46,17 @@ inline std::size_t
   return block_size_member::value();
 }
 
+
+template<std::size_t Size, std::size_t Align>
+inline bit::memory::allocator_info
+  bit::memory::aligned_block_allocator<Size,Align>::info()
+  const noexcept
+{
+  return {"aligned_block_allocator",this};
+}
+
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
 template<std::size_t Size, std::size_t Align>

--- a/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
@@ -49,6 +49,18 @@ inline std::size_t
 }
 
 template<std::size_t Size, std::size_t Align>
+inline bit::memory::allocator_info
+  bit::memory::growing_aligned_block_allocator<Size,Align>::info()
+  const noexcept
+{
+  return {"growing_aligned_block_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Private Member Functions
+//-----------------------------------------------------------------------------
+
+template<std::size_t Size, std::size_t Align>
 inline void bit::memory::growing_aligned_block_allocator<Size,Align>::grow()
 {
   if( base_type::m_growths_remaining == 0 ) return;
@@ -58,7 +70,7 @@ inline void bit::memory::growing_aligned_block_allocator<Size,Align>::grow()
 }
 
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
 template<std::size_t Size, std::size_t Align>

--- a/include/bit/memory/block_allocators/detail/growing_malloc_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_malloc_block_allocator.inl
@@ -40,8 +40,19 @@ inline std::size_t bit::memory::growing_malloc_block_allocator<Size>
 }
 
 template<std::size_t Size>
-inline void bit::memory::growing_malloc_block_allocator<Size>
-  ::grow()
+inline bit::memory::allocator_info
+  bit::memory::growing_malloc_block_allocator<Size>::info()
+   const noexcept
+{
+  return {"growing_malloc_block_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Private Member Functions
+//-----------------------------------------------------------------------------
+
+template<std::size_t Size>
+inline void bit::memory::growing_malloc_block_allocator<Size>::grow()
 {
   if( base_type::m_growths_remaining == 0 ) return;
 
@@ -51,7 +62,7 @@ inline void bit::memory::growing_malloc_block_allocator<Size>
 
 
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
 template<std::size_t Size>

--- a/include/bit/memory/block_allocators/detail/growing_new_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_new_block_allocator.inl
@@ -40,8 +40,19 @@ inline std::size_t bit::memory::growing_new_block_allocator<Size>
 }
 
 template<std::size_t Size>
-inline void bit::memory::growing_new_block_allocator<Size>
-  ::grow()
+inline bit::memory::allocator_info
+  bit::memory::growing_new_block_allocator<Size>::info()
+   const noexcept
+{
+  return {"growing_new_block_allocator",this};
+}
+
+//-----------------------------------------------------------------------------
+// Private Member Functions
+//-----------------------------------------------------------------------------
+
+template<std::size_t Size>
+inline void bit::memory::growing_new_block_allocator<Size>::grow()
 {
   if( base_type::m_growths_remaining == 0 ) return;
 
@@ -51,7 +62,7 @@ inline void bit::memory::growing_new_block_allocator<Size>
 
 
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
 template<std::size_t Size>

--- a/include/bit/memory/block_allocators/detail/malloc_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/malloc_block_allocator.inl
@@ -34,10 +34,17 @@ template<std::size_t Size>
 inline std::size_t bit::memory::malloc_block_allocator<Size>
   ::next_block_size()
    const noexcept
- {
+{
   return block_size_member::value();
- }
+}
 
+template<std::size_t Size>
+inline bit::memory::allocator_info
+  bit::memory::malloc_block_allocator<Size>::info()
+  const noexcept
+{
+  return {"malloc_block_allocator",this};
+}
 
 //-----------------------------------------------------------------------------
 // Comparisons

--- a/include/bit/memory/block_allocators/detail/new_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/new_block_allocator.inl
@@ -38,6 +38,13 @@ inline std::size_t bit::memory::new_block_allocator<Size>
   return block_size_member::value();
 }
 
+template<std::size_t Size>
+inline bit::memory::allocator_info bit::memory::new_block_allocator<Size>::info()
+  const noexcept
+{
+  return {"new_block_allocator",this};
+}
+
 //-----------------------------------------------------------------------------
 // Comparisons
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/block_allocators/detail/null_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/null_block_allocator.inl
@@ -13,35 +13,41 @@ inline bit::memory::owner<bit::memory::memory_block>
 }
 
 inline void bit::memory::null_block_allocator
-  ::deallocate_block( owner<memory_block> )
+  ::deallocate_block( owner<memory_block> block )
   noexcept
 {
-  // Do nothing
+  BIT_MEMORY_UNUSED(block);
 }
 
 //-----------------------------------------------------------------------------
 // Observers
 //-----------------------------------------------------------------------------
 
-std::size_t bit::memory::null_block_allocator::next_block_size()
+inline std::size_t bit::memory::null_block_allocator::next_block_size()
   const noexcept
 {
   return 0;
 }
 
+inline bit::memory::allocator_info  bit::memory::null_block_allocator::info()
+  const noexcept
+{
+  return {"null_allocator",this};
+}
+
 //-----------------------------------------------------------------------------
-// Comparisons
+// Equality
 //-----------------------------------------------------------------------------
 
-bool bit::memory::operator==( const null_block_allocator&,
-                              const null_block_allocator& )
+inline bool bit::memory::operator==( const null_block_allocator&,
+                                     const null_block_allocator& )
   noexcept
 {
   return true;
 }
 
-bool bit::memory::operator!=( const null_block_allocator&,
-                              const null_block_allocator& )
+inline bool bit::memory::operator!=( const null_block_allocator&,
+                                     const null_block_allocator& )
   noexcept
 {
   return false;

--- a/include/bit/memory/block_allocators/detail/stack_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/stack_block_allocator.inl
@@ -49,5 +49,12 @@ inline std::size_t bit::memory::stack_block_allocator<BlockSize,Blocks,Align>
   return BlockSize;
 }
 
+template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align>
+inline bit::memory::allocator_info
+  bit::memory::stack_block_allocator<BlockSize,Blocks,Align>::info()
+  const noexcept
+{
+  return {"stack_block_allocator",this};
+}
 
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_STACK_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/static_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/static_block_allocator.inl
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-bit::memory::owner<bit::memory::memory_block>
+inline bit::memory::owner<bit::memory::memory_block>
   bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
   ::allocate_block()
   noexcept
@@ -17,7 +17,7 @@ bit::memory::owner<bit::memory::memory_block>
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-void bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
+inline void bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
   ::deallocate_block( owner<memory_block> block )
   noexcept
 {
@@ -29,11 +29,19 @@ void bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-std::size_t bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
+inline std::size_t bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
   ::next_block_size()
   const noexcept
 {
   return BlockSize;
+}
+
+template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
+inline bit::memory::allocator_info
+  bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>::info()
+  const noexcept
+{
+  return {"static_block_allocator",this};
 }
 
 //-----------------------------------------------------------------------------
@@ -41,7 +49,7 @@ std::size_t bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-bit::memory::memory_block_cache&
+inline bit::memory::memory_block_cache&
   bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>::block_cache()
   noexcept
 {

--- a/include/bit/memory/block_allocators/detail/thread_local_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/thread_local_block_allocator.inl
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-bit::memory::owner<bit::memory::memory_block>
+inline bit::memory::owner<bit::memory::memory_block>
   bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
   ::allocate_block()
   noexcept
@@ -17,7 +17,7 @@ bit::memory::owner<bit::memory::memory_block>
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-void bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
+inline void bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
   ::deallocate_block( owner<memory_block> block )
   noexcept
 {
@@ -29,11 +29,19 @@ void bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-std::size_t bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
+inline std::size_t bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
   ::next_block_size()
   const noexcept
 {
   return BlockSize;
+}
+
+template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
+inline bit::memory::allocator_info
+  bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>::info()
+  const noexcept
+{
+  return {"thread_local_block_allocator",this};
 }
 
 //-----------------------------------------------------------------------------
@@ -41,7 +49,7 @@ std::size_t bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-bit::memory::memory_block_cache&
+inline bit::memory::memory_block_cache&
   bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>::block_cache()
   noexcept
 {
@@ -59,8 +67,5 @@ bit::memory::memory_block_cache&
 
   return cache;
 }
-
-
-
 
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_THREAD_LOCAL_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
@@ -11,12 +11,13 @@
 
 #include "detail/cached_block_allocator.hpp" // cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
-#include "../detail/dynamic_size_type.hpp"   // dynamic_size, detail::dynamic_size_type
 
-#include "../owner.hpp"             // owner
-#include "../memory_block.hpp"      // memory_block
-#include "../pointer_utilities.hpp" // is_power_of_two
+#include "../detail/dynamic_size_type.hpp" // dynamic_size, detail::dynamic_size_type
 #include "../aligned_memory.hpp"    // aligned_allocate
+#include "../allocator_info.hpp"    // allocator_info
+#include "../memory_block.hpp"      // memory_block
+#include "../owner.hpp"             // owner
+#include "../pointer_utilities.hpp" // is_power_of_two
 
 #include <type_traits> // std::true_type, std::false_type, etc
 #include <cstddef>     // std::size_t
@@ -196,6 +197,14 @@ namespace bit {
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
 
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'growing_aligned_block_allocator'.
+      /// Use a named_growing_aligned_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
+
       //-----------------------------------------------------------------------
       // Private Member Functions
       //-----------------------------------------------------------------------
@@ -206,7 +215,7 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t Size, std::size_t Align>

--- a/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
@@ -11,11 +11,12 @@
 
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
-#include "../detail/dynamic_size_type.hpp"   // detail::dynamic_size_type
 
-#include "../macros.hpp"                   // BIT_MEMORY_UNLIKELY
-#include "../owner.hpp"                    // owner
-#include "../memory_block.hpp"             // memory_block
+#include "../detail/dynamic_size_type.hpp" // detail::dynamic_size_type
+#include "../allocator_info.hpp" // allocator_info
+#include "../macros.hpp"         // BIT_MEMORY_UNLIKELY
+#include "../memory_block.hpp"   // memory_block
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::size_t, std::ptrdiff_t
 #include <cstdlib>     // std::malloc, std::free
@@ -147,6 +148,14 @@ namespace bit {
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
 
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'growing_malloc_block_allocator'.
+      /// Use a named_growing_malloc_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
+
       //----------------------------------------------------------------------
       // Private Members
       //----------------------------------------------------------------------
@@ -155,14 +164,13 @@ namespace bit {
       /// \brief Grows the size of each block, if possible
       void grow();
 
-
       template<std::size_t S>
       friend bool operator==( const growing_malloc_block_allocator<S>&,
                               const growing_malloc_block_allocator<S>& rhs ) noexcept;
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t Size>
@@ -174,7 +182,7 @@ namespace bit {
                      const growing_malloc_block_allocator<Size>& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
-    // Utiltiies
+    // Utilities
     //-------------------------------------------------------------------------
 
     using dynamic_growing_malloc_block_allocator = growing_malloc_block_allocator<dynamic_size>;

--- a/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
@@ -11,11 +11,12 @@
 
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
-#include "../detail/dynamic_size_type.hpp"   // detail::dynamic_size_type
 
-#include "../macros.hpp"                   // BIT_MEMORY_UNLIKELY
-#include "../owner.hpp"                    // owner
-#include "../memory_block.hpp"             // memory_block
+#include "../detail/dynamic_size_type.hpp" // detail::dynamic_size_type
+#include "../allocator_info.hpp" // allocator_info
+#include "../macros.hpp"         // BIT_MEMORY_UNLIKELY
+#include "../memory_block.hpp"   // memory_block
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::size_t, std::ptrdiff_t
 #include <new>         // std::malloc, std::free
@@ -147,6 +148,14 @@ namespace bit {
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
 
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'growing_new_block_allocator'.
+      /// Use a named_growing_new_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
+
       //----------------------------------------------------------------------
       // Private Members
       //----------------------------------------------------------------------
@@ -161,7 +170,7 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t Size>
@@ -173,7 +182,7 @@ namespace bit {
                      const growing_new_block_allocator<Size>& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
-    // Utiltiies
+    // Utilities
     //-------------------------------------------------------------------------
 
     using dynamic_growing_new_block_allocator = growing_new_block_allocator<dynamic_size>;

--- a/include/bit/memory/block_allocators/growing_virtual_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_virtual_block_allocator.hpp
@@ -11,8 +11,9 @@
 
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
-#include "../owner.hpp"              // owner
+#include "../allocator_info.hpp"     // allocator_info
 #include "../memory_block_cache.hpp" // memory_block_cache
+#include "../owner.hpp"              // owner
 
 #include <cstddef> // std::size_t
 
@@ -88,6 +89,14 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'growing_virtual_block_allocator'.
+      /// Use a named_growing_virtual_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/block_allocators/malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/malloc_block_allocator.hpp
@@ -11,12 +11,12 @@
 
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
-#include "../detail/dynamic_size_type.hpp"   // detail::dynamic_size_type
 
-#include "../macros.hpp"                   // BIT_MEMORY_UNLIKELY
-#include "../owner.hpp"                    // owner
-#include "../memory_block.hpp"             // memory_block
-
+#include "../detail/dynamic_size_type.hpp" // detail::dynamic_size_type
+#include "../allocator_info.hpp" // allocator_info
+#include "../macros.hpp"         // BIT_MEMORY_UNLIKELY
+#include "../memory_block.hpp"   // memory_block
+#include "../owner.hpp"          // owner
 
 #include <cstddef>     // std::size_t, std::ptrdiff_t
 #include <cstdlib>     // std::malloc, std::free
@@ -139,10 +139,18 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'malloc_block_allocator'.
+      /// Use a named_malloc_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t Size>

--- a/include/bit/memory/block_allocators/new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/new_block_allocator.hpp
@@ -13,10 +13,10 @@
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 
 #include "../detail/dynamic_size_type.hpp" // detail::dynamic_size_type
+#include "../allocator_info.hpp"           // allocator_info
 #include "../macros.hpp"                   // BIT_MEMORY_UNLIKELY
-#include "../owner.hpp"                    // owner
 #include "../memory_block.hpp"             // memory_block
-
+#include "../owner.hpp"                    // owner
 
 #include <new>         // ::new
 #include <type_traits> // std::true_type, std::false_type, etc
@@ -149,10 +149,18 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'new_block_allocator'.
+      /// Use a named_new_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     template<std::size_t S>

--- a/include/bit/memory/block_allocators/null_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/null_block_allocator.hpp
@@ -10,8 +10,10 @@
 
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
-#include "../owner.hpp"         // owner
-#include "../memory_block.hpp"  // memory_block
+#include "../allocator_info.hpp" // allocator_info
+#include "../macros.hpp"         // BIT_MEMORY_UNUSED
+#include "../memory_block.hpp"   // memory_block
+#include "../owner.hpp"          // owner
 
 #include <type_traits> // std::integral_constant, std::true_false
 #include <cstddef>     // std::max_align_t
@@ -91,10 +93,18 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'null_block_allocator'.
+      /// Use a named_null_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
     };
 
     //-------------------------------------------------------------------------
-    // Comparisons
+    // Equality
     //-------------------------------------------------------------------------
 
     bool operator==( const null_block_allocator& lhs,

--- a/include/bit/memory/block_allocators/policy_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/policy_block_allocator.hpp
@@ -53,7 +53,7 @@ namespace bit {
     /// BlockAllocator by proxying the same functions defined in the
     /// BlockAllocator concept.
     ///
-    /// \satisfies BlockAllocator
+    /// \satisfies{BlockAllocator}
     ///
     /// \tparam BlockAllocator The block allocator to use
     /// \tparam MemoryTagger A class used for tagging memory on allocations and

--- a/include/bit/memory/block_allocators/stack_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/stack_block_allocator.hpp
@@ -11,6 +11,7 @@
 
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
+#include "../allocator_info.hpp"     // allocator_info
 #include "../macros.hpp"             // BIT_MEMORY_UNUSED
 #include "../memory_block.hpp"       // memory_block
 #include "../memory_block_cache.hpp" // memory_block_cache
@@ -105,6 +106,14 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'stack_block_allocator'.
+      /// Use a named_stack_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/block_allocators/static_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/static_block_allocator.hpp
@@ -115,6 +115,14 @@ namespace bit {
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
 
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'static_block_allocator'.
+      /// Use a named_static_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
+
       //----------------------------------------------------------------------
       // Private Members
       //----------------------------------------------------------------------
@@ -130,8 +138,11 @@ namespace bit {
 
     //-------------------------------------------------------------------------
 
-    template<std::size_t BlockSize, std::size_t Blocks=1, std::size_t Align=alignof(std::max_align_t)>
-    using named_static_block_allocator = detail::named_block_allocator<static_block_allocator<BlockSize,Blocks,Align>>;
+    template<std::size_t BlockSize,
+             std::size_t Blocks = 1,
+             std::size_t Align = alignof(std::max_align_t),
+             typename Tag = void>
+    using named_static_block_allocator = detail::named_block_allocator<static_block_allocator<BlockSize,Blocks,Align,Tag>>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
@@ -10,9 +10,11 @@
 #define BIT_MEMORY_BLOCK_ALLOCATORS_THREAD_LOCAL_BLOCK_ALLOCATOR_HPP
 
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
-#include "../owner.hpp"              // owner
+
+#include "../allocator_info.hpp"     // allocator_info
 #include "../memory_block.hpp"       // memory_block
 #include "../memory_block_cache.hpp" // memory_block_cache
+#include "../owner.hpp"              // owner
 
 #include <cstddef> // std::size_t, std::max_align_t
 #include <cassert> // assert
@@ -116,6 +118,14 @@ namespace bit {
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
 
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'thread_local_block_allocator'.
+      /// Use a named_thread_local_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
+
       //----------------------------------------------------------------------
       // Private Members
       //----------------------------------------------------------------------
@@ -129,8 +139,19 @@ namespace bit {
       static memory_block_cache& block_cache() noexcept;
     };
 
+    //-------------------------------------------------------------------------
+    // Utilities
+    //-------------------------------------------------------------------------
+
+    template<std::size_t BlockSize,
+             std::size_t Blocks = 1,
+             std::size_t Align = alignof(std::max_align_t),
+             typename Tag = void>
+    using named_thread_local_block_allocator = detail::named_block_allocator<thread_local_block_allocator<BlockSize,Blocks,Align,Tag>>;
 
   } // namespace memory
 } // namespace bit
+
+#include "detail/thread_local_block_allocator.inl"
 
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_THREAD_LOCAL_BLOCK_ALLOCATOR_HPP */

--- a/include/bit/memory/block_allocators/virtual_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/virtual_block_allocator.hpp
@@ -10,8 +10,9 @@
 
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
-#include "../owner.hpp"              // owner
+#include "../allocator_info.hpp"     // allocator_info
 #include "../memory_block_cache.hpp" // memory_block_cache
+#include "../owner.hpp"              // owner
 
 #include <cstddef> // std::size_t
 
@@ -86,6 +87,14 @@ namespace bit {
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
+
+      /// \brief Gets the info about this allocator
+      ///
+      /// This defaults to 'virtual_block_allocator'.
+      /// Use a named_virtual_block_allocator to override this
+      ///
+      /// \return the info for this allocator
+      allocator_info info() const noexcept;
 
       //-----------------------------------------------------------------------
       // Private Members

--- a/include/bit/memory/concepts/Allocator.hpp
+++ b/include/bit/memory/concepts/Allocator.hpp
@@ -123,7 +123,8 @@ namespace bit {
     /// \endcode
     /// \c a returns an allocator_info object describing the allocator
     ///
-    /// Default returns "unknown allocator"
+    /// The default value is implementation-defined, but should somehow identify
+    /// the allocator
     ///
     /// - - - - -
     ///

--- a/include/bit/memory/detail/allocator_traits.inl
+++ b/include/bit/memory/detail/allocator_traits.inl
@@ -240,7 +240,7 @@ inline bit::memory::allocator_info
 {
   BIT_MEMORY_UNUSED(alloc);
 
-  return {"Unnamed",std::addressof(alloc)};
+  return {typeid(Allocator).name(),std::addressof(alloc)};
 }
 
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_ALLOCATOR_TRAITS_INL */

--- a/include/bit/memory/detail/block_allocator_traits.inl
+++ b/include/bit/memory/detail/block_allocator_traits.inl
@@ -69,7 +69,7 @@ inline bit::memory::allocator_info
 {
   BIT_MEMORY_UNUSED(alloc);
 
-  return {"Unnamed",std::addressof(alloc)};
+  return {typeid(BlockAllocator).name(),std::addressof(alloc)};
 }
 
 //-----------------------------------------------------------------------------

--- a/src/bit/memory/block_allocators/growing_virtual_block_allocator.cpp
+++ b/src/bit/memory/block_allocators/growing_virtual_block_allocator.cpp
@@ -94,3 +94,9 @@ std::size_t bit::memory::growing_virtual_block_allocator::next_block_size()
 {
   return virtual_memory_page_size() * static_cast<std::size_t>(m_active_page + 1);
 }
+
+bit::memory::allocator_info bit::memory::growing_virtual_block_allocator::info()
+  const noexcept
+{
+  return {"growing_virtual_block_allocator",this};
+}

--- a/src/bit/memory/block_allocators/virtual_block_allocator.cpp
+++ b/src/bit/memory/block_allocators/virtual_block_allocator.cpp
@@ -78,3 +78,9 @@ std::size_t bit::memory::virtual_block_allocator::next_block_size()
 {
   return virtual_memory_page_size();
 }
+
+bit::memory::allocator_info bit::memory::virtual_block_allocator::info()
+  const noexcept
+{
+  return {"virtual_block_allocator",this};
+}


### PR DESCRIPTION
All allocators now define a default `info()` function that returns an `allocator_info` object that defaults to the name of the allocator. This is a better identifier than the `allocator_traits<Allocator>::info( ... )`.

Names of allocators can still be renamed via the `named_..._allocator` types (which shadows the default `info` definition)