### PR TITLE
Disabled extensions in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include(CopyTargetProperties)
 option(BIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS "Include each header independently in a .cpp file to determine header self-containment" off)
 option(BIT_MEMORY_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" off)
 option(BIT_MEMORY_GENERATE_DOCUMENTATION "Generates doxygen documentation" off)
+option(BIT_MEMORY_COMPILE_BENCHMARKS "Compile the benchmark tests for this library" off)
 
 project("BitMemory")
 
@@ -39,7 +40,8 @@ message(STATUS "bit::memory ${BIT_MEMORY_VERSION}")
 #-----------------------------------------------------------------------------
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED true)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+set(CMAKE_CXX_EXTENSIONS off)
 
 make_version_header("${CMAKE_CURRENT_BINARY_DIR}/include/bit/memory/version.hpp"
   MAJOR ${BIT_MEMORY_VERSION_MAJOR}
@@ -270,14 +272,14 @@ target_include_directories(bit_memory PUBLIC
 # Add DEBUG, NDEBUG, and RELEASE macro definitions
 target_compile_definitions(bit_memory PUBLIC
   $<$<CONFIG:DEBUG>:DEBUG>
-  $<$<CONFIG:RELEASE>:DEBUG RELEASE>
+  $<$<CONFIG:RELEASE>:RELEASE>
 )
 
 # Add compiler-specific flags
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  target_compile_options(bit_memory PUBLIC -Wall -Wstrict-aliasing -pedantic)
+  target_compile_options(bit_memory PRIVATE -Wall -Wstrict-aliasing -pedantic -Werror)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-  target_compile_options(bit_memory PUBLIC -Wall -Wstrict-aliasing -pedantic)
+  target_compile_options(bit_memory PRIVATE -Wall -Wstrict-aliasing -pedantic -Werror)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
   # TODO: Determine MSVC necessary compiler flags
 endif()
@@ -306,6 +308,14 @@ endif()
 
 if( BIT_MEMORY_COMPILE_UNIT_TESTS )
   add_subdirectory(test)
+endif()
+
+#-----------------------------------------------------------------------------
+# bit::memory : Benchmarks
+#-----------------------------------------------------------------------------
+
+if( BIT_MEMORY_COMPILE_BENCHMARKS )
+  add_subdirectory(benchmarks)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/src/bit/memory/posix/aligned_memory.cpp
+++ b/src/bit/memory/posix/aligned_memory.cpp
@@ -13,7 +13,10 @@ void* bit::memory::aligned_malloc( std::size_t size, std::size_t align )
   noexcept
 {
   void* result_ptr = nullptr;
-  ::posix_memalign(&result_ptr, align, size);
+  if( ::posix_memalign(&result_ptr, align, size) )
+  {
+    return nullptr;
+  }
   return result_ptr;
 }
 


### PR DESCRIPTION
Prior to this, extensions were enabled for the language -- causing
this library to be compiled with `-std=gnu++14` instead of `-std=c++14`