### PR TITLE
Corrected target name in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,26 +260,26 @@ set(source_files
 # bit::memory: Library
 #-----------------------------------------------------------------------------
 
-add_library(bit_memory ${source_files} ${headers} ${inline_headers})
-add_library(bit::memory ALIAS bit_memory)
+add_library(memory ${source_files} ${headers} ${inline_headers})
+add_library(bit::memory ALIAS memory)
 
 # Add include directories
-target_include_directories(bit_memory PUBLIC
+target_include_directories(memory PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
 )
 
 # Add DEBUG, NDEBUG, and RELEASE macro definitions
-target_compile_definitions(bit_memory PUBLIC
+target_compile_definitions(memory PUBLIC
   $<$<CONFIG:DEBUG>:DEBUG>
   $<$<CONFIG:RELEASE>:RELEASE>
 )
 
 # Add compiler-specific flags
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  target_compile_options(bit_memory PRIVATE -Wall -Wstrict-aliasing -pedantic -Werror)
+  target_compile_options(memory PRIVATE -Wall -Wstrict-aliasing -pedantic -Werror)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-  target_compile_options(bit_memory PRIVATE -Wall -Wstrict-aliasing -pedantic -Werror)
+  target_compile_options(memory PRIVATE -Wall -Wstrict-aliasing -pedantic -Werror)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
   # TODO: Determine MSVC necessary compiler flags
 endif()
@@ -291,10 +291,10 @@ endif()
 if( BIT_MEMORY_COMPILE_HEADER_SELF_CONTAINMENT_TESTS )
 
   # Add containment test and alias as 'bit::memory::header_self_containment_test
-  add_header_self_containment_test(bit_memory_header_self_containment_test ${headers})
-  add_library(bit::memory::header_self_containment_test ALIAS bit_memory_header_self_containment_test)
+  add_header_self_containment_test(memory_header_self_containment_test ${headers})
+  add_library(bit::memory::header_self_containment_test ALIAS memory_header_self_containment_test)
 
-  copy_target_properties(bit_memory_header_self_containment_test bit_memory PROPERTIES
+  copy_target_properties(memory_header_self_containment_test memory PROPERTIES
     COMPILE_DEFINITIONS
     COMPILE_OPTIONS
     INCLUDE_DIRECTORIES
@@ -336,7 +336,7 @@ if( EXISTS "$ENV{BIT_HOME}" )
   set(CMAKE_INSTALL_PREFIX "$ENV{BIT_HOME}")
 endif()
 
-export_library( TARGETS bit_memory
+export_library( TARGETS memory
                 PACKAGE Memory
                 VERSION ${BIT_MEMORY_VERSION}
                 MAJOR_VERSION ${BIT_MEMORY_VERSION_MAJOR}


### PR DESCRIPTION
The 'bit_memory' target installs incorrectly when using a namespace
identifier of 'bit', which produces 'bit::bit_memory' instead of just
'bit::memory'