### PR TITLE
Feature/stateless concept overhaul

### DIFF
--- a/include/bit/memory/allocators/aligned_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_allocator.hpp
@@ -36,7 +36,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      using is_stateless      = std::true_type;
       using default_alignment = std::integral_constant<std::size_t,1>;
 
       //-----------------------------------------------------------------------

--- a/include/bit/memory/allocators/aligned_offset_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_offset_allocator.hpp
@@ -36,7 +36,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      using is_stateless      = std::true_type;
       using default_alignment = std::integral_constant<std::size_t,1>;
 
       //-----------------------------------------------------------------------

--- a/include/bit/memory/allocators/malloc_allocator.hpp
+++ b/include/bit/memory/allocators/malloc_allocator.hpp
@@ -38,7 +38,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      using is_stateless      = std::true_type;
       using default_alignment = std::integral_constant<std::size_t,alignof(std::max_align_t)>;
 
       //-----------------------------------------------------------------------

--- a/include/bit/memory/allocators/new_allocator.hpp
+++ b/include/bit/memory/allocators/new_allocator.hpp
@@ -38,7 +38,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      using is_stateless      = std::true_type;
       using default_alignment = std::integral_constant<std::size_t,alignof(std::max_align_t)>;
 
       //-----------------------------------------------------------------------

--- a/include/bit/memory/allocators/null_allocator.hpp
+++ b/include/bit/memory/allocators/null_allocator.hpp
@@ -40,7 +40,6 @@ namespace bit {
       //-----------------------------------------------------------------------
     public:
 
-      using is_stateless      = std::true_type;
       using default_alignment = std::integral_constant<std::size_t,1>;
 
       //-----------------------------------------------------------------------

--- a/include/bit/memory/allocators/policy_allocator.hpp
+++ b/include/bit/memory/allocators/policy_allocator.hpp
@@ -79,10 +79,10 @@ namespace bit {
       using default_alignment = allocator_default_alignment<ExtendedAllocator>;
       using max_alignment     = allocator_max_alignment<ExtendedAllocator>;
       using is_stateless = std::integral_constant<bool,is_stateless<ExtendedAllocator>::value &&
-                                                       std::is_empty<MemoryTagger>::value &&
-                                                       std::is_empty<MemoryTracker>::value &&
-                                                       std::is_empty<BoundsChecker>::value &&
-                                                       std::is_empty<BasicLockable>::value>;
+                                                       is_stateless<MemoryTagger>::value &&
+                                                       is_stateless<MemoryTracker>::value &&
+                                                       is_stateless<BoundsChecker>::value &&
+                                                       is_stateless<BasicLockable>::value>;
 
       using lock_type    = BasicLockable;
       using tracker_type = MemoryTracker;

--- a/include/bit/memory/block_allocators/aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/aligned_block_allocator.hpp
@@ -33,7 +33,6 @@ namespace bit {
           detail::dynamic_size_type<1,Align>
       {
         using default_block_alignment = std::integral_constant<std::size_t,Align>;
-        using is_stateless            = std::true_type;
 
         aligned_block_allocator_base() noexcept = default;
         aligned_block_allocator_base( aligned_block_allocator_base&& ) noexcept = default;
@@ -49,7 +48,6 @@ namespace bit {
         : detail::dynamic_size_type<0,Size>,
           detail::dynamic_size_type<1,dynamic_size>
       {
-        using is_stateless = std::false_type;
 
         aligned_block_allocator_base( std::size_t align ) noexcept
           : detail::dynamic_size_type<1,dynamic_size>( align )
@@ -70,7 +68,6 @@ namespace bit {
           detail::dynamic_size_type<1,Align>
       {
         using default_block_alignment = std::integral_constant<std::size_t,Align>;
-        using is_stateless            = std::false_type;
 
         aligned_block_allocator_base( std::size_t size ) noexcept
           : detail::dynamic_size_type<0,dynamic_size>( size )
@@ -90,8 +87,6 @@ namespace bit {
         : detail::dynamic_size_type<0,dynamic_size>,
           detail::dynamic_size_type<1,dynamic_size>
       {
-        using is_stateless = std::false_type;
-
         aligned_block_allocator_base( std::size_t size, std::size_t align ) noexcept
           : detail::dynamic_size_type<0,dynamic_size>( size ),
             detail::dynamic_size_type<1,dynamic_size>( align )

--- a/include/bit/memory/block_allocators/malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/malloc_block_allocator.hpp
@@ -29,8 +29,6 @@ namespace bit {
       struct malloc_block_allocator_base
         : detail::dynamic_size_type<0,Size>
       {
-        using is_stateless = std::true_type;
-
         malloc_block_allocator_base() noexcept = default;
         malloc_block_allocator_base( malloc_block_allocator_base&& ) noexcept = default;
         malloc_block_allocator_base( const malloc_block_allocator_base& ) noexcept = default;
@@ -42,8 +40,6 @@ namespace bit {
       struct malloc_block_allocator_base<dynamic_size>
         : detail::dynamic_size_type<0,dynamic_size>
       {
-        using is_stateless = std::false_type;
-
         explicit malloc_block_allocator_base( std::size_t size )
           : detail::dynamic_size_type<0,dynamic_size>(size)
         {

--- a/include/bit/memory/block_allocators/new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/new_block_allocator.hpp
@@ -29,8 +29,6 @@ namespace bit {
       struct new_block_allocator_base
         : detail::dynamic_size_type<0,Size>
       {
-        using is_stateless = std::true_type;
-
         new_block_allocator_base() noexcept = default;
         new_block_allocator_base( new_block_allocator_base&& ) noexcept = default;
         new_block_allocator_base( const new_block_allocator_base& ) noexcept = default;

--- a/include/bit/memory/block_allocators/null_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/null_block_allocator.hpp
@@ -35,7 +35,6 @@ namespace bit {
     public:
 
       using default_block_alignment = std::integral_constant<std::size_t,1>;
-      using is_stateless            = std::true_type;
 
       //-----------------------------------------------------------------------
       // Constructor / Assignment

--- a/include/bit/memory/concepts/Stateless.hpp
+++ b/include/bit/memory/concepts/Stateless.hpp
@@ -33,36 +33,23 @@ namespace bit {
   ///
   /// **Requirements**
   ///
-  /// - DefaultConstructible
-  /// - CopyConstructible
-  /// - MoveConstructible
-  /// - CopyAssignable
-  /// - MoveASsignable
-  /// - EqualityComparable
+  /// - Empty
+  /// - TriviallyDefaultConstructible
+  /// - TriviallyCopyConstructible
+  /// - TriviallyMoveConstructible
+  /// - TriviallyCopyAssignable
+  /// - TriviallyMoveASsignable
   ///
-  /// Additionally, it must satisfy the followowing:
+  /// Alternatively, the following state may be specified to override the
+  /// determination of a concept.
   ///
   /// **Provided**
   ///
   /// - \c S - a Stateless type
-  /// - \c s - an instance of type \c S
+  /// - \c s - an instance of \c S
   ///
   /// the following expressions must be well-formed with the expected
   /// reproduceable side-effects:
-  ///
-  /// \code
-  /// S() == S()
-  /// \endcode
-  /// returns true
-  ///
-  /// - - - - -
-  ///
-  /// \code
-  /// S() != S()
-  /// \endcode
-  /// returns false
-  ///
-  /// - - - - -
   ///
   /// \code
   /// S s1{};              // default ctor
@@ -86,37 +73,17 @@ namespace bit {
     concept bool Stateless = requires(T a, T b) {
         { a == b } -> bool;
         { a != b } -> bool;
-    } && std::is_empty<T>::value
+    } || (std::is_empty<T>::value
       && std::is_trivially_constructible<T>::value
       && std::is_trivially_destructible<T>::value
-      && std::is_move_constructible<T>::value
-      && std::is_copy_constructible<T>::value
-      && std::is_move_assignable<T>::value
-      && std::is_copy_assignable<T>::value;
+      && std::is_trivially_move_constructible<T>::value
+      && std::is_trivially_copy_constructible<T>::value
+      && std::is_trivially_copyable<T>::value
+      && std::is_trivial<T>::value)
 
 #endif
 
     namespace detail {
-
-      template<typename T, typename = void>
-      struct is_equality_comparable : std::false_type{};
-
-      template<typename T>
-      struct is_equality_comparable<T,void_t<
-        decltype(std::declval<bool&>() = (std::declval<T&>()==std::declval<T&>()))>
-      > : std::true_type{};
-
-      //-----------------------------------------------------------------------
-
-      template<typename T, typename = void>
-      struct is_inequality_comparable : std::false_type{};
-
-      template<typename T>
-      struct is_inequality_comparable<T,void_t<
-        decltype(std::declval<bool&>() = (std::declval<T&>()!=std::declval<T&>()))>
-      > : std::true_type{};
-
-      //-----------------------------------------------------------------------
 
       template<typename T, typename = void>
       struct concept_is_stateless : std::false_type{};
@@ -135,16 +102,15 @@ namespace bit {
     /// \tparam T the type to check
     template<typename T>
     struct is_stateless : std::integral_constant<bool,
-      detail::concept_is_stateless<T>::value &&
-      detail::is_equality_comparable<T>::value &&
-      detail::is_inequality_comparable<T>::value &&
-      std::is_empty<T>::value &&
+      detail::concept_is_stateless<T>::value ||
+     (std::is_empty<T>::value &&
       std::is_trivially_constructible<T>::value &&
       std::is_trivially_destructible<T>::value &&
-      std::is_move_constructible<T>::value &&
-      std::is_copy_constructible<T>::value &&
-      std::is_move_assignable<T>::value &&
-      std::is_copy_assignable<T>::value
+      std::is_trivially_move_constructible<T>::value &&
+      std::is_trivially_copy_constructible<T>::value &&
+      std::is_trivially_copy_assignable<T>::value &&
+      std::is_trivially_move_assignable<T>::value &&
+      std::is_trivial<T>::value)
     >{};
 
     /// \brief Convenience template variable to extract the \c ::value member


### PR DESCRIPTION
This overhauls the `Stateless` concept to now check for trivial construction/assignment/destruction and emptiness, rather than requiring `is_stateless`.
`is_stateless` is still provided as an extension to support logically stateless, but actually stateful classes