### PR TITLE
Add unit tests for block allocators

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ install:
   # Download Catch
   - set CATCH_DIR=%cd%\catch\include
   - mkdir %CATCH_DIR%
-  - appveyor DownloadFile https://github.com/philsquared/Catch/releases/download/v1.10.0/catch.hpp -FileName %CATCH_DIR%\catch.hpp
+  - appveyor DownloadFile https://github.com/catchorg/Catch2/releases/download/v2.0.1/catch.hpp -FileName %CATCH_DIR%\catch.hpp
 
 #####################
 # Update Submodules #

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ install:
 
   # Get dependency 'catch'
   - mkdir -p catch/include
-  - wget https://github.com/philsquared/Catch/releases/download/v1.10.0/catch.hpp -P catch/include
+  - wget https://github.com/catchorg/Catch2/releases/download/v2.0.1/catch.hpp -P catch/include
   - export CATCH_DIR=$(pwd)/catch/include
 
   # Install cmake 3.9.4 for Linux

--- a/include/bit/memory/block_allocator_traits.hpp
+++ b/include/bit/memory/block_allocator_traits.hpp
@@ -12,7 +12,6 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_BLOCK_ALLOCATOR_TRAITS_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_BLOCK_ALLOCATOR_TRAITS_HPP
 
-#include "concepts/Stateless.hpp"      // is_stateless
 #include "concepts/BlockAllocator.hpp" // is_block_allocator
 
 #include "allocator_reference.hpp" // allocator_reference
@@ -54,8 +53,6 @@ namespace bit {
       //----------------------------------------------------------------------
     public:
 
-      // qualified 'bit::memory::' to avoid '-fpermissive' errors with gcc
-      using is_stateless        = bit::memory::is_stateless<BlockAllocator>;
       using has_block_alignment = block_allocator_has_default_block_alignment<BlockAllocator>;
 
       //----------------------------------------------------------------------

--- a/include/bit/memory/block_allocators/aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/aligned_block_allocator.hpp
@@ -12,6 +12,8 @@
 #include "detail/cached_block_allocator.hpp" // cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 
+#include "malloc_block_allocator.hpp"
+
 #include "../detail/dynamic_size_type.hpp" // dynamic_size, detail::dynamic_size_type
 #include "../aligned_memory.hpp"    // aligned_allocate
 #include "../allocator_info.hpp"    // allocator_info
@@ -20,7 +22,7 @@
 #include "../pointer_utilities.hpp" // is_power_of_two
 
 #include <type_traits> // std::true_type, std::false_type, etc
-#include <cstddef>     // std::size_t
+#include <cstddef>     // std::size_t, std::max_align_t
 #include <cassert>     // assert
 
 namespace bit {
@@ -104,6 +106,14 @@ namespace bit {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief An allocator that allocates over-aligned memory
+    ///
+    /// \note This allocator should only be used for over-aligned memory blocks
+    ///       where required. It does not make sense to be used if the required
+    ///       alignment of each block is less than or equal to
+    ///       \c alignof(std::max_align_t) -- as this fundamental alignment is
+    ///       required of both the 'new_block_allocator' and
+    ///       'malloc_block_allocator' without requiring any additional
+    ///       overhead
     ///
     /// \tparam Size The size of the block
     /// \tparam Align The alignment of block
@@ -213,23 +223,30 @@ namespace bit {
     /// \tparam Size The size of the block
     /// \tparam Align The alignment of block
     template<std::size_t Size,std::size_t Align>
-    using cached_aligned_block_allocator = detail::cached_block_allocator<aligned_block_allocator<Size,Align>>;
+    using cached_aligned_block_allocator
+      = detail::cached_block_allocator<aligned_block_allocator<Size,Align>>;
 
-    using dynamic_aligned_block_allocator = aligned_block_allocator<dynamic_size,dynamic_size>;
+    using dynamic_aligned_block_allocator
+      = aligned_block_allocator<dynamic_size,dynamic_size>;
 
-    using cached_dynamic_aligned_block_allocator = detail::cached_block_allocator<dynamic_aligned_block_allocator>;
+    using cached_dynamic_aligned_block_allocator
+      = detail::cached_block_allocator<dynamic_aligned_block_allocator>;
 
     //-------------------------------------------------------------------------
 
     template<std::size_t Size,std::size_t Align>
-    using named_aligned_block_allocator = detail::named_block_allocator<aligned_block_allocator<Size,Align>>;
+    using named_aligned_block_allocator
+      = detail::named_block_allocator<aligned_block_allocator<Size,Align>>;
 
     template<std::size_t Size,std::size_t Align>
-    using named_cached_aligned_block_allocator = detail::named_block_allocator<cached_aligned_block_allocator<Size,Align>>;
+    using named_cached_aligned_block_allocator
+      = detail::named_block_allocator<cached_aligned_block_allocator<Size,Align>>;
 
-    using named_dynamic_aligned_block_allocator = detail::named_block_allocator<dynamic_aligned_block_allocator>;
+    using named_dynamic_aligned_block_allocator
+      = detail::named_block_allocator<dynamic_aligned_block_allocator>;
 
-    using named_cached_dynamic_aligned_block_allocator = detail::named_block_allocator<cached_dynamic_aligned_block_allocator>;
+    using named_cached_dynamic_aligned_block_allocator
+      = detail::named_block_allocator<cached_dynamic_aligned_block_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
@@ -87,6 +87,16 @@ namespace bit {
         void deallocate_block( owner<memory_block> block );
 
         //---------------------------------------------------------------------
+        // Observers
+        //---------------------------------------------------------------------
+      public:
+
+        /// \brief Queries the next block size expected from this allocator
+        ///
+        /// \return the size of the next allocated block
+        std::size_t next_block_size() const noexcept;
+
+        //---------------------------------------------------------------------
         // Private Members
         //---------------------------------------------------------------------
       private:

--- a/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
@@ -40,6 +40,11 @@ namespace bit {
         //---------------------------------------------------------------------
       public:
 
+        /// \brief Default-constructs the underlying cached_block_allocator
+        ///
+        /// \note This is only enabled if BlockAllocator has it enabled
+        cached_block_allocator() = default;
+
         /// \brief Constructs a cached_block_allocator from another allocator
         ///
         /// \param alloc the underlying allocator to construct out of

--- a/include/bit/memory/block_allocators/detail/cached_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/cached_block_allocator.inl
@@ -1,9 +1,9 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_CACHED_BLOCK_ALLOCATOR_INL
 #define BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_CACHED_BLOCK_ALLOCATOR_INL
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Constructor / Destructor
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename BlockAllocator>
 template<typename Arg0, typename...Args, typename>
@@ -14,7 +14,7 @@ inline bit::memory::detail::cached_block_allocator<BlockAllocator>
 
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename BlockAllocator>
 inline bit::memory::detail::cached_block_allocator<BlockAllocator>
@@ -26,9 +26,9 @@ inline bit::memory::detail::cached_block_allocator<BlockAllocator>
   }
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Block Allocations
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename BlockAllocator>
 inline bit::memory::owner<bit::memory::memory_block>
@@ -37,13 +37,28 @@ inline bit::memory::owner<bit::memory::memory_block>
   return m_cache.request_block( static_cast<BlockAllocator&>(*this) );
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 template<typename BlockAllocator>
 inline void bit::memory::detail::cached_block_allocator<BlockAllocator>
   ::deallocate_block( owner<memory_block> block )
 {
   m_cache.store_block( std::move(block) );
+}
+
+//-----------------------------------------------------------------------------
+// Block Allocations
+//-----------------------------------------------------------------------------
+
+template<typename BlockAllocator>
+inline std::size_t bit::memory::detail::cached_block_allocator<BlockAllocator>
+  ::next_block_size()
+  const noexcept
+{
+  if( !m_cache.empty() ) {
+    return m_cache.peek().size();
+  }
+  return BlockAllocator::next_block_size();
 }
 
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_CACHED_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
@@ -45,7 +45,7 @@ inline std::size_t
   bit::memory::growing_aligned_block_allocator<Size,Align>::next_block_size()
   const noexcept
 {
-  return block_size_member::value();
+  return block_size_member::value() * base_type::m_multiplier;
 }
 
 template<std::size_t Size, std::size_t Align>

--- a/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
@@ -1,7 +1,6 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_GROWING_ALIGNED_BLOCK_ALLOCATOR_INL
 #define BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_GROWING_ALIGNED_BLOCK_ALLOCATOR_INL
 
-
 //=============================================================================
 // growing_aligned_block_allocator
 //=============================================================================

--- a/include/bit/memory/block_allocators/detail/policy_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/policy_block_allocator.inl
@@ -10,10 +10,11 @@
 //-----------------------------------------------------------------------------
 
 template<typename BlockAllocator, typename Tagger, typename Tracker, typename Lock>
-template<typename...Args,typename>
+template<typename Arg0, typename...Args,typename>
 inline bit::memory::policy_block_allocator<BlockAllocator,Tagger,Tracker,Lock>
-  ::policy_block_allocator( Args&&...args )
-  : base_type( std::forward_as_tuple( std::forward<Args>(args)... ),
+  ::policy_block_allocator( Arg0&& arg0, Args&&...args )
+  : base_type( std::forward_as_tuple( std::forward<Arg0>(arg0),
+                                      std::forward<Args>(args)... ),
                std::make_tuple(),
                std::make_tuple(),
                std::make_tuple() )
@@ -105,7 +106,6 @@ inline const Tracker&
 //-----------------------------------------------------------------------------
 
 template<typename BlockAllocator, typename Tagger, typename Tracker, typename Lock>
-template<typename,typename>
 inline bit::memory::allocator_info
   bit::memory::policy_block_allocator<BlockAllocator,Tagger,Tracker,Lock>
   ::info()
@@ -121,17 +121,6 @@ inline std::size_t
   const noexcept
 {
   return traits_type::next_block_size( detail::get<0>(*this) );
-}
-
-
-template<typename BlockAllocator, typename Tagger, typename Tracker, typename Lock>
-template<typename,typename>
-inline std::size_t
-  bit::memory::policy_block_allocator<BlockAllocator,Tagger,Tracker,Lock>
-  ::next_block_alignment()
-  const noexcept
-{
-  return traits_type::next_block_alignment( detail::get<0>(*this) );
 }
 
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_POLICY_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/static_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/static_block_allocator.inl
@@ -2,6 +2,14 @@
 #define BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_STATIC_BLOCK_ALLOCATOR_INL
 
 //-----------------------------------------------------------------------------
+// Static Variables
+//-----------------------------------------------------------------------------
+
+template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
+alignas(Align) char bit::memory::static_block_allocator<BlockSize,Blocks,Align,Tag>
+  ::s_storage[BlockSize*Blocks] = {};
+
+//-----------------------------------------------------------------------------
 // Block Allocation
 //-----------------------------------------------------------------------------
 
@@ -33,6 +41,11 @@ inline std::size_t bit::memory::static_block_allocator<BlockSize,Blocks,Align,Ta
   ::next_block_size()
   const noexcept
 {
+  auto& cache = block_cache();
+
+  if( cache.empty() ) {
+    return 0;
+  }
   return BlockSize;
 }
 

--- a/include/bit/memory/block_allocators/detail/thread_local_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/thread_local_block_allocator.inl
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------------
 
 template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
-alignas(Align) char bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
+alignas(Align) thread_local char bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
   ::s_storage[bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>::s_storage_size];
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/block_allocators/detail/thread_local_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/thread_local_block_allocator.inl
@@ -2,6 +2,14 @@
 #define BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_THREAD_LOCAL_BLOCK_ALLOCATOR_INL
 
 //-----------------------------------------------------------------------------
+// Static Variables
+//-----------------------------------------------------------------------------
+
+template<std::size_t BlockSize, std::size_t Blocks, std::size_t Align, typename Tag>
+alignas(Align) char bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>
+  ::s_storage[bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag>::s_storage_size];
+
+//-----------------------------------------------------------------------------
 // Block Allocation
 //-----------------------------------------------------------------------------
 
@@ -21,6 +29,10 @@ inline void bit::memory::thread_local_block_allocator<BlockSize,Blocks,Align,Tag
   ::deallocate_block( owner<memory_block> block )
   noexcept
 {
+  assert( block.data() >= static_cast<void*>(&s_storage[0]) );
+  assert( block.data() < static_cast<void*>(&s_storage[s_storage_size]) );
+  assert( block != nullblock );
+
   block_cache().store_block( block );
 }
 
@@ -33,6 +45,7 @@ inline std::size_t bit::memory::thread_local_block_allocator<BlockSize,Blocks,Al
   ::next_block_size()
   const noexcept
 {
+  if( block_cache().empty() ) return 0;
   return BlockSize;
 }
 
@@ -56,8 +69,9 @@ inline bit::memory::memory_block_cache&
   static thread_local auto cache = []()
   {
     auto temp_cache = memory_block_cache{};
+    auto* s = static_cast<char*>(s_storage); // cast array to pointer
     for( auto i=0; i<Blocks; ++i ) {
-      auto* p = static_cast<void*>(&s_storage[i * BlockSize]);
+      auto* p = static_cast<void*>(s + (i * BlockSize));
 
       temp_cache.store_block( {p, BlockSize} );
     }

--- a/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
@@ -16,6 +16,7 @@
 #include "../aligned_memory.hpp"    // aligned_allocate
 #include "../allocator_info.hpp"    // allocator_info
 #include "../memory_block.hpp"      // memory_block
+#include "../macros.hpp"            // BIT_MEMORY_UNLIKELY
 #include "../owner.hpp"             // owner
 #include "../pointer_utilities.hpp" // is_power_of_two
 

--- a/include/bit/memory/block_allocators/malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/malloc_block_allocator.hpp
@@ -161,24 +161,31 @@ namespace bit {
     // Utiltiies
     //-------------------------------------------------------------------------
 
-    using dynamic_malloc_block_allocator = malloc_block_allocator<dynamic_size>;
+    using dynamic_malloc_block_allocator
+      = malloc_block_allocator<dynamic_size>;
 
     template<std::size_t Size>
-    using cached_malloc_block_allocator = detail::cached_block_allocator<malloc_block_allocator<Size>>;
+    using cached_malloc_block_allocator
+      = detail::cached_block_allocator<malloc_block_allocator<Size>>;
 
-    using cached_dynamic_malloc_block_allocator = detail::cached_block_allocator<dynamic_malloc_block_allocator>;
+    using cached_dynamic_malloc_block_allocator
+      = detail::cached_block_allocator<dynamic_malloc_block_allocator>;
 
     //-------------------------------------------------------------------------
 
     template<std::size_t Size>
-    using named_malloc_block_allocator = detail::named_block_allocator<malloc_block_allocator<Size>>;
+    using named_malloc_block_allocator
+      = detail::named_block_allocator<malloc_block_allocator<Size>>;
 
     template<std::size_t Size>
-    using named_cached_malloc_block_allocator = detail::named_block_allocator<cached_malloc_block_allocator<Size>>;
+    using named_cached_malloc_block_allocator
+      = detail::named_block_allocator<cached_malloc_block_allocator<Size>>;
 
-    using named_dynamic_malloc_block_allocator = detail::named_block_allocator<dynamic_malloc_block_allocator>;
+    using named_dynamic_malloc_block_allocator
+      = detail::named_block_allocator<dynamic_malloc_block_allocator>;
 
-    using named_cached_dynamic_malloc_block_allocator = detail::named_block_allocator<cached_dynamic_malloc_block_allocator>;
+    using named_cached_dynamic_malloc_block_allocator
+      = detail::named_block_allocator<cached_dynamic_malloc_block_allocator>;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/block_allocators/policy_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/policy_block_allocator.hpp
@@ -72,7 +72,10 @@ namespace bit {
         public detail::policy_block_allocator_base<BlockAllocator>
     {
       using traits_type = block_allocator_traits<BlockAllocator>;
-      using base_type = detail::ebo_storage<BlockAllocator,MemoryTagger,MemoryTracker,BasicLockable>;
+      using base_type = detail::ebo_storage<BlockAllocator,
+                                            MemoryTagger,
+                                            MemoryTracker,
+                                            BasicLockable>;
 
       //-----------------------------------------------------------------------
       // Public Member Types
@@ -82,9 +85,9 @@ namespace bit {
       using lock_type    = BasicLockable;
       using tracker_type = MemoryTracker;
       using is_stateless = std::integral_constant<bool,is_stateless<BlockAllocator>::value &&
-                                                       std::is_empty<MemoryTagger>::value &&
-                                                       std::is_empty<MemoryTracker>::value &&
-                                                       std::is_empty<BasicLockable>::value>;
+                                                       is_stateless<MemoryTagger>::value &&
+                                                       is_stateless<MemoryTracker>::value &&
+                                                       is_stateless<BasicLockable>::value>;
 
       //-----------------------------------------------------------------------
       // Constructors
@@ -98,8 +101,11 @@ namespace bit {
       ///        arguments to it
       ///
       /// \param args the arguments to forward to the underlying block allocator
-      template<typename...Args, typename = std::enable_if_t<std::is_constructible<BlockAllocator,Args...>::value>>
-      policy_block_allocator( Args&&...args );
+      template<typename Arg0, typename...Args,
+               typename = std::enable_if_t<
+                 std::is_constructible<BlockAllocator,Arg0,Args...>::value &&
+                 !std::is_same<Arg0,std::decay_t<policy_block_allocator>>::value>>
+      policy_block_allocator( Arg0&& arg0, Args&&...args );
 
       /// \brief Move-constructs this policy_block_allocator from an existing
       ///        one
@@ -175,22 +181,12 @@ namespace bit {
       ///       \c info()
       ///
       /// \return the allocator info
-      template<typename U = BlockAllocator, typename = std::enable_if_t<block_allocator_has_info<U>::value>>
       allocator_info info() const noexcept;
 
       /// \brief Queries the next block size expected from this allocator
       ///
       /// \return the size of the next allocated block
       std::size_t next_block_size() const noexcept;
-
-      /// \brief Queries the next block alignment expected from this allocator
-      ///
-      /// \note This is only enabled if the underlying BlockAllocator supports
-      ///       \c next_block_alignment()
-      ///
-      /// \return the next block alignment
-      template<typename U = BlockAllocator, typename = std::enable_if_t<block_allocator_has_next_block_alignment<U>::value>>
-      std::size_t next_block_alignment() const noexcept;
     };
 
   } // namespace memory

--- a/include/bit/memory/block_allocators/stack_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/stack_block_allocator.hpp
@@ -19,6 +19,7 @@
 #include "../pointer_utilities.hpp"  // is_power_of_two
 
 #include <cstddef> // std::max_align_t
+#include <cassert> // assert
 
 namespace bit {
   namespace memory {
@@ -42,9 +43,12 @@ namespace bit {
              std::size_t Align=alignof(std::max_align_t)>
     class stack_block_allocator
     {
-      static_assert( Blocks > 0,"Must have at least one block" );
-      static_assert( is_power_of_two(Align), "Alignment must be a power of two" );
-      static_assert( BlockSize % Align == 0, "Block size must must be an increment of the block size" );
+      static_assert( Blocks > 0,
+                     "Must have at least one block" );
+      static_assert( is_power_of_two(Align),
+                     "Alignment must be a power of two" );
+      static_assert( Blocks == 1 || BlockSize % Align == 0,
+                     "Block size must must be an increment of the alignment" );
 
       //-----------------------------------------------------------------------
       // Public Member Types
@@ -120,9 +124,9 @@ namespace bit {
       //-----------------------------------------------------------------------
     private:
 
-      static constexpr auto size = BlockSize * Blocks;
+      static constexpr auto s_storage_size = BlockSize * Blocks;
 
-      alignas(Align) char m_storage[size];
+      alignas(Align) char m_storage[s_storage_size];
       memory_block_cache  m_cache;
     };
 

--- a/include/bit/memory/block_allocators/static_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/static_block_allocator.hpp
@@ -46,13 +46,11 @@ namespace bit {
              typename Tag = void>
     class static_block_allocator
     {
-      static constexpr auto s_min_alignment = ((BlockSize > Align) ? Align : BlockSize);
-
       static_assert( Blocks > 0,
                      "Must have at least one block" );
       static_assert( is_power_of_two(Align),
                      "Alignment must be a power of two" );
-      static_assert( BlockSize % s_min_alignment == 0,
+      static_assert( Blocks == 1 || BlockSize % Align == 0,
                      "Block size must must be an increment of the alignment" );
 
       //-----------------------------------------------------------------------
@@ -133,7 +131,8 @@ namespace bit {
       //-----------------------------------------------------------------------
     private:
 
-      alignas(Align) static char s_storage[BlockSize * Blocks];
+      static constexpr auto s_storage_size = BlockSize * Blocks;
+      alignas(Align) static char s_storage[s_storage_size];
 
       /// \brief Gets the static memory_block_cache for this allocator
       ///

--- a/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
@@ -131,7 +131,8 @@ namespace bit {
       //----------------------------------------------------------------------
     private:
 
-      alignas(Align) static thread_local char s_storage[BlockSize * Blocks];
+      static constexpr auto s_storage_size = BlockSize * Blocks;
+      alignas(Align) static thread_local char s_storage[s_storage_size];
 
       /// \brief Gets the static memory_block_cache for this allocator
       ///

--- a/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
@@ -22,7 +22,7 @@
 namespace bit {
   namespace memory {
 
-    //////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// \brief This is a block allocator that distributes blocks of static
     ///        memory that is local to the specific thread.
     ///
@@ -41,28 +41,31 @@ namespace bit {
     ///
     /// \satisfies{BlockAllocator}
     /// \satisfies{Stateless}
-    //////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     template<std::size_t BlockSize,
              std::size_t Blocks = 1,
              std::size_t Align = alignof(std::max_align_t),
              typename Tag = void>
     class thread_local_block_allocator
     {
-      static_assert( Blocks > 0,"Must have at least one block" );
-      static_assert( is_power_of_two(Align), "Alignment must be a power of two" );
-      static_assert( BlockSize % Align == 0, "Block size must must be an increment of the block size" );
+      static_assert( Blocks > 0,
+                     "Must have at least one block" );
+      static_assert( is_power_of_two(Align),
+                     "Alignment must be a power of two" );
+      static_assert( Blocks == 1 || BlockSize % Align == 0,
+                     "Block size must must be an increment of the block size" );
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Public Members
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       using block_size      = std::integral_constant<std::size_t,BlockSize>;
       using block_alignment = std::integral_constant<std::size_t,Align>;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Constructor
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Default constructs a thread_local_block_allocator
@@ -79,7 +82,7 @@ namespace bit {
       thread_local_block_allocator( const thread_local_block_allocator& other ) noexcept = default;
 
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
 
       /// \brief Move-assigns a thread_local_block_allocator from another one
       ///
@@ -93,9 +96,9 @@ namespace bit {
       /// \return reference to \c (*this)
       thread_local_block_allocator& operator=( const thread_local_block_allocator& other ) noexcept = default;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Block Allocations
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Allocates a memory block of size \c Size
@@ -126,9 +129,9 @@ namespace bit {
       /// \return the info for this allocator
       allocator_info info() const noexcept;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Private Members
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     private:
 
       static constexpr auto s_storage_size = BlockSize * Blocks;

--- a/include/bit/memory/concepts/BlockAllocator.hpp
+++ b/include/bit/memory/concepts/BlockAllocator.hpp
@@ -47,7 +47,7 @@ namespace bit {
     /// side-effects:
     ///
     /// \code
-    /// a.allocate_block()
+    /// memory_block b = a.allocate_block()
     /// \endcode
     ///
     /// Allocates a \c memory_block of implementation-specific size
@@ -71,12 +71,12 @@ namespace bit {
 #if __cplusplus >= 202000L
   // TODO(bitwize) replace 202000L with the correct __cplusplus when certified
 
-    template<typename B>
-    concept BlockAllocator = requires( B b, memory_block block )
+    template<typename A>
+    concept BlockAllocator = requires( A a, memory_block block )
     {
-      { b.allocate_block() } -> memory_block;
-      { b.deallocate_block( block ) } -> void;
-      { b.next_block_size() } -> std::size_t;
+      { block = a.allocate_block() } -> memory_block;
+      { a.deallocate_block( block ) } -> void;
+      { a.next_block_size() } -> std::size_t;
     };
 #endif
 
@@ -156,7 +156,8 @@ namespace bit {
     ///
     /// \tparam T the type to check
     template<typename T>
-    constexpr std::size_t block_allocator_default_block_alignment_v = block_allocator_has_default_block_alignment<T>::value;
+    constexpr std::size_t block_allocator_default_block_alignment_v
+      = block_allocator_has_default_block_alignment<T>::value;
 
     //-------------------------------------------------------------------------
 
@@ -174,7 +175,8 @@ namespace bit {
     ///
     /// \tparam T the type to check
     template<typename T>
-    constexpr std::size_t block_allocator_has_next_block_size_v = block_allocator_has_next_block_size<T>::value;
+    constexpr std::size_t block_allocator_has_next_block_size_v
+      = block_allocator_has_next_block_size<T>::value;
 
     //-------------------------------------------------------------------------
 
@@ -192,7 +194,8 @@ namespace bit {
     ///
     /// \tparam T the type to check
     template<typename T>
-    constexpr std::size_t block_allocator_has_next_block_alignment_v = block_allocator_has_next_block_alignment<T>::value;
+    constexpr std::size_t block_allocator_has_next_block_alignment_v
+      = block_allocator_has_next_block_alignment<T>::value;
 
     //-------------------------------------------------------------------------
 
@@ -210,7 +213,8 @@ namespace bit {
     ///
     /// \tparam T the type to check
     template<typename T>
-    constexpr bool block_allocator_has_info_v = block_allocator_has_info<T>::value;
+    constexpr bool block_allocator_has_info_v
+      = block_allocator_has_info<T>::value;
 
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/concepts/BoundsChecker.hpp
+++ b/include/bit/memory/concepts/BoundsChecker.hpp
@@ -180,7 +180,8 @@ namespace bit {
       detail::bounds_checker_has_check_front_fence<T>::value &&
       detail::bounds_checker_has_check_back_fence<T>::value &&
       detail::bounds_checker_has_front_size<T>::value &&
-      detail::bounds_checker_has_back_size<T>::value
+      detail::bounds_checker_has_back_size<T>::value &&
+      std::is_default_constructible<T>::value
      >{};
 
     /// \brief Convenience template variable for extracting the result from

--- a/include/bit/memory/concepts/MemoryTagger.hpp
+++ b/include/bit/memory/concepts/MemoryTagger.hpp
@@ -91,7 +91,8 @@ namespace bit {
     template<typename T>
     struct is_memory_tagger : std::integral_constant<bool,
       detail::memory_tagger_has_tag_allocation<T>::value &&
-      detail::memory_tagger_has_tag_deallocation<T>::value
+      detail::memory_tagger_has_tag_deallocation<T>::value &&
+      std::is_default_constructible<T>::value
     >{};
 
     /// \brief Convenience template variable for extracting the result from

--- a/include/bit/memory/concepts/MemoryTracker.hpp
+++ b/include/bit/memory/concepts/MemoryTracker.hpp
@@ -143,7 +143,8 @@ namespace bit {
       detail::memory_tracker_has_on_allocate<T>::value &&
       detail::memory_tracker_has_on_deallocate<T>::value &&
       detail::memory_tracker_has_on_deallocate_all<T>::value &&
-      detail::memory_tracker_has_finalize<T>::value
+      detail::memory_tracker_has_finalize<T>::value &&
+      std::is_default_constructible<T>::value
     >{};
 
     /// \brief Convenience template variable for extracting the result from

--- a/include/bit/memory/detail/memory_block_cache.inl
+++ b/include/bit/memory/detail/memory_block_cache.inl
@@ -97,13 +97,14 @@ template<typename BlockAllocator>
 inline bit::memory::owner<bit::memory::memory_block>
   bit::memory::memory_block_cache::request_block( BlockAllocator& alloc )
 {
-  auto block = m_head;
   if( m_head.data() ) {
+    auto block = m_head;
+
     m_head = (*static_cast<memory_block*>(block.data()));
-  } else {
-    block = alloc.allocate_block();
+
+    return block;
   }
-  return block;
+  return alloc.allocate_block();
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/detail/memory_block_cache.inl
+++ b/include/bit/memory/detail/memory_block_cache.inl
@@ -1,13 +1,13 @@
 #ifndef BIT_MEMORY_DETAIL_MEMORY_BLOCK_CACHE_INL
 #define BIT_MEMORY_DETAIL_MEMORY_BLOCK_CACHE_INL
 
-//============================================================================
+//=============================================================================
 // memory_block_cache
-//============================================================================
+//=============================================================================
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Constructor
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline bit::memory::memory_block_cache::memory_block_cache()
   noexcept
@@ -16,9 +16,9 @@ inline bit::memory::memory_block_cache::memory_block_cache()
 
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Observers
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline bool bit::memory::memory_block_cache::empty()
   const noexcept
@@ -26,53 +26,61 @@ inline bool bit::memory::memory_block_cache::empty()
   return m_head.data() == nullptr;
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline std::size_t bit::memory::memory_block_cache::size()
   const noexcept
 {
   auto result = std::size_t{0};
 
-  auto block = m_head;
-  while( block != nullblock ) {
+  auto block = &m_head;
+  while( *block != nullblock ) {
     ++result;
-    block = *static_cast<const memory_block*>(block.data());
+    block = static_cast<const memory_block*>(block->data());
   }
   return result;
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline std::size_t bit::memory::memory_block_cache::size_bytes()
   const noexcept
 {
   auto result = std::size_t{0};
 
-  auto block = m_head;
-  while( block != nullblock ) {
-    result += block.size();
-    block = *static_cast<const memory_block*>(block.data());
+  auto block = &m_head;
+  while( *block != nullblock ) {
+    result += block->size();
+    block = static_cast<const memory_block*>(block->data());
   }
 
   return result;
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline bool bit::memory::memory_block_cache::contains( const void* ptr )
   const noexcept
 {
   auto block = &m_head;
-  while( block ) {
+  while( *block != nullblock ) {
     if( block->contains(ptr) ) return true;
     block = static_cast<const memory_block*>(block->data());
   }
   return false;
 }
 
-//----------------------------------------------------------------------------
-// Caching
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// Element Access
+//-----------------------------------------------------------------------------
+
+inline const bit::memory::memory_block& bit::memory::memory_block_cache::peek()
+  const noexcept
+{
+  return m_head;
+}
+
+//-----------------------------------------------------------------------------
 
 inline bit::memory::owner<bit::memory::memory_block>
   bit::memory::memory_block_cache::request_block()
@@ -84,8 +92,6 @@ inline bit::memory::owner<bit::memory::memory_block>
   }
   return block;
 }
-
-//----------------------------------------------------------------------------
 
 template<typename BlockAllocator>
 inline bit::memory::owner<bit::memory::memory_block>
@@ -100,7 +106,7 @@ inline bit::memory::owner<bit::memory::memory_block>
   return block;
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline void bit::memory::memory_block_cache::steal_block( memory_block_cache& other )
   noexcept
@@ -110,20 +116,21 @@ inline void bit::memory::memory_block_cache::steal_block( memory_block_cache& ot
   }
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline void bit::memory::memory_block_cache::store_block( owner<memory_block> block )
   noexcept
 {
+  assert( block != nullblock );
   assert( alignof(memory_block) <= align_of(block.data()) );
 
   uninitialized_construct_at<memory_block>( block.data(), m_head );
   m_head = block;
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Modifiers
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline void bit::memory::memory_block_cache::swap( memory_block_cache& other )
   noexcept
@@ -131,9 +138,9 @@ inline void bit::memory::memory_block_cache::swap( memory_block_cache& other )
   m_head.swap(other.m_head);
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // Free Functions
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 inline void bit::memory::swap( memory_block_cache& lhs, memory_block_cache& rhs )
   noexcept

--- a/include/bit/memory/detail/unaligned_memory.inl
+++ b/include/bit/memory/detail/unaligned_memory.inl
@@ -29,7 +29,7 @@ inline T bit::memory::load_unaligned( const void* p )
 
   std::memcpy(&result[0],p,sizeof(T));
 
-  return reinterpret_cast<T&>(result);;
+  return *reinterpret_cast<T*>(&result[0]);;
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/detail/unaligned_memory.inl
+++ b/include/bit/memory/detail/unaligned_memory.inl
@@ -25,11 +25,12 @@ inline T bit::memory::load_unaligned( const void* p )
 {
   static_assert( std::is_trivially_copyable<T>::value,
                  "T must be trivially copyable" );
-  alignas(T) char result[sizeof(T)];
 
-  std::memcpy(&result[0],p,sizeof(T));
+  std::aligned_storage_t<sizeof(T),alignof(T)> result;
 
-  return *reinterpret_cast<T*>(static_cast<char*>(&result[0]));
+  std::memcpy(&result,p,sizeof(T));
+
+  return *reinterpret_cast<T*>(&result);
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/detail/unaligned_memory.inl
+++ b/include/bit/memory/detail/unaligned_memory.inl
@@ -8,6 +8,9 @@
 template<typename T>
 inline void bit::memory::store_unaligned( void* p, const T& val )
 {
+  static_assert( std::is_trivially_copyable<T>::value,
+                 "T must be trivially copyable" );
+
   auto val_ptr = reinterpret_cast<const char*>( std::addressof(val) );
 
   std::memcpy(p,val_ptr,sizeof(T));
@@ -20,10 +23,13 @@ inline void bit::memory::store_unaligned( void* p, const T& val )
 template<typename T>
 inline T bit::memory::load_unaligned( const void* p )
 {
-  T result;
-  std::memcpy(reinterpret_cast<char*>(&result),p,sizeof(T));
+  static_assert( std::is_trivially_copyable<T>::value,
+                 "T must be trivially copyable" );
+  alignas(T) char result[sizeof(T)];
 
-  return result;
+  std::memcpy(&result[0],p,sizeof(T));
+
+  return reinterpret_cast<T&>(result);;
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/detail/unaligned_memory.inl
+++ b/include/bit/memory/detail/unaligned_memory.inl
@@ -29,7 +29,7 @@ inline T bit::memory::load_unaligned( const void* p )
 
   std::memcpy(&result[0],p,sizeof(T));
 
-  return *reinterpret_cast<T*>(&result[0]);;
+  return *reinterpret_cast<T*>(static_cast<char*>(&result[0]));
 }
 
 //-----------------------------------------------------------------------------

--- a/include/bit/memory/detail/uninitialized_storage.inl
+++ b/include/bit/memory/detail/uninitialized_storage.inl
@@ -14,9 +14,11 @@ inline T* bit::memory::uninitialized_construct_at( void* p, Args&&...args )
 namespace bit { namespace memory { namespace detail {
 
   template<typename T, typename Tuple, std::size_t...Idxs>
-  inline T* uninitialized_construct_from_tuple( void* p, Tuple&& tuple, std::index_sequence<Idxs...> )
+  inline T* uninitialized_construct_from_tuple( void* p,
+                                                Tuple&& tuple,
+                                                std::index_sequence<Idxs...> )
   {
-    return new (p) T( std::get<Idxs>(std::forward<Tuple>(tuple))... );
+    return new (p) T( std::get<Idxs>( std::forward<Tuple>(tuple) )... );
   }
 
 } } } // namespace bit::memory::detail
@@ -25,30 +27,63 @@ namespace bit { namespace memory { namespace detail {
 template<typename T, typename Tuple>
 inline T* bit::memory::uninitialized_construct_from_tuple( void* p, Tuple&& tuple )
 {
-  const auto seq = std::make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>{};
+  using decay_type = std::decay_t<Tuple>;
+  static constexpr auto tuple_size = std::tuple_size<decay_type>::value;
+  const auto seq = std::make_index_sequence<tuple_size>{};
 
   return detail::uninitialized_construct_from_tuple<T>( p, std::forward<Tuple>(tuple), seq );
 }
+
+namespace bit { namespace memory { namespace detail {
+  template<typename T, typename...Args>
+  inline T* uninitialized_construct_array_at( std::true_type,
+                                              void* p,
+                                              std::size_t n,
+                                              Args&&...args )
+  {
+    auto current   = static_cast<T*>(p);
+    const auto end = current + n;
+
+    while( current != end ) {
+      uninitialized_construct_at( current++, std::forward<Args>(args)... );
+    }
+
+    return static_cast<T*>(p);
+  }
+
+  template<typename T, typename...Args>
+  inline T* uninitialized_construct_array_at( std::false_type,
+                                              void* p,
+                                              std::size_t n,
+                                              Args&&...args )
+  {
+    auto current   = static_cast<T*>(p);
+    const auto end = current + n;
+
+    try {
+      while( current != end ) {
+        uninitialized_construct_at( current, std::forward<Args>(args)... );
+        ++current; // done as separate statement in case construction throws
+      }
+    } catch ( ... ) {
+      const auto rend = static_cast<T*>(p) - 1;
+      while( --current != rend ) {
+        destroy_at(current);
+      }
+      throw;
+    }
+    return static_cast<T*>(p);
+  }
+
+} } } // namespace bit::memory::detail
 
 template<typename T>
 inline T* bit::memory::uninitialized_construct_array_at( void* p,
                                                          std::size_t n )
 {
-  auto current   = static_cast<T*>(p);
-  const auto end = current + n;
+  static const auto tag = std::is_nothrow_constructible<T>{};
 
-  try {
-    while( current != end ) {
-      uninitialized_construct_at(current++);
-    }
-  } catch ( ... ) {
-    const auto rend = static_cast<T*>(p)--;
-    while( current != rend ) {
-      destroy_at(current--);
-    }
-    throw;
-  }
-  return static_cast<T*>(p);
+  return detail::uninitialized_construct_array_at<T>( tag, p, n );
 }
 
 template<typename T>
@@ -56,21 +91,9 @@ inline T* bit::memory::uninitialized_construct_array_at( void* p,
                                                          std::size_t n,
                                                          const T& copy )
 {
-  auto current   = static_cast<T*>(p);
-  const auto end = current + n;
+  static const auto tag = std::is_nothrow_copy_constructible<T>{};
 
-  try {
-    while( current != end ) {
-      uninitialized_construct_at(current++, copy);
-    }
-  } catch ( ... ) {
-    const auto rend = static_cast<T*>(p) - 1;
-    while( current != rend ) {
-      destroy_at(current--);
-    }
-    throw;
-  }
-  return static_cast<T*>(p);
+  return detail::uninitialized_construct_array_at<T>( tag, p, n );
 }
 
 namespace bit { namespace memory { namespace detail {

--- a/include/bit/memory/memory_block_cache.hpp
+++ b/include/bit/memory/memory_block_cache.hpp
@@ -19,7 +19,7 @@
 namespace bit {
   namespace memory {
 
-    //////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     /// \brief A cache containing an intrinsically linked list of
     ///        memory_blocks
     ///
@@ -27,12 +27,16 @@ namespace bit {
     /// Memory blocks may originate from different allocators, and represent
     /// different regions of memory -- however this is not the recommended
     /// practice.
-    /////////////////////////////////////////////////////////////////////////
+    ///
+    /// Every memory_block in the memory_block_cache must be aligned to at
+    /// least \c alignof(memory_block) bytes -- otherwise it is undefined
+    /// behavior
+    ///////////////////////////////////////////////////////////////////////////
     class memory_block_cache
     {
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Constructor / Assignment
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Default constructs a block cache
@@ -46,7 +50,7 @@ namespace bit {
       // Deleted copy constructor
       memory_block_cache( const memory_block_cache& other ) = delete;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
 
       // Deleted move assignment
       memory_block_cache& operator=( memory_block_cache&& other ) = delete;
@@ -54,9 +58,9 @@ namespace bit {
       // Deleted copy assignment
       memory_block_cache& operator=( const memory_block_cache& other ) = delete;
 
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
       // Observers
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
     public:
 
       /// \brief Returns whether or not this memory_block_cache is empty
@@ -65,6 +69,9 @@ namespace bit {
       bool empty() const noexcept;
 
       /// \brief Returns the number of memory_blocks in this cache
+      ///
+      /// This function is lazily computed, and is written with \c O(n)
+      /// complexity
       ///
       /// \return the number of memory_blocks in this cache
       std::size_t size() const noexcept;
@@ -80,10 +87,20 @@ namespace bit {
       /// \return \c true whether \p ptr
       bool contains( const void* ptr ) const noexcept;
 
-      //----------------------------------------------------------------------
-      // Caching
-      //----------------------------------------------------------------------
+      //-----------------------------------------------------------------------
+      // Element Access
+      //-----------------------------------------------------------------------
     public:
+
+      /// \brief Views the front memory block of this cache
+      ///
+      /// \pre !empty()
+      ///
+      /// \note It is undefined behaviour to invoke this function if the cache
+      ///       is empty
+      ///
+      /// \return the front cache entry
+      const memory_block& peek() const noexcept;
 
       /// \brief Requests a block from the current block cache.
       ///
@@ -106,6 +123,11 @@ namespace bit {
       void steal_block( memory_block_cache& other ) noexcept;
 
       /// \brief Stores an allocated block inside this memory_block_cache
+      ///
+      /// \pre \c block.data() points to memory that is aligned to at least
+      ///      \c alignof(memory_block) bytes.
+      ///
+      /// \pre \c block points to a valid memory_block
       ///
       /// \param block the block to store
       void store_block( owner<memory_block> block ) noexcept;

--- a/include/bit/memory/unaligned_memory.hpp
+++ b/include/bit/memory/unaligned_memory.hpp
@@ -12,6 +12,7 @@
 #include <cstring>     // std::memcpy
 #include <memory>      // std::addressof
 #include <type_traits> // std::is_trivially_copyable
+#include <utility>     // std::aligned_storage
 
 namespace bit {
   namespace memory {

--- a/include/bit/memory/unaligned_memory.hpp
+++ b/include/bit/memory/unaligned_memory.hpp
@@ -8,9 +8,10 @@
 #ifndef BIT_MEMORY_UNALIGNED_MEMORY_HPP
 #define BIT_MEMORY_UNALIGNED_MEMORY_HPP
 
-#include <cstdint> // std::uint8_t, std::uint16_t, etc
-#include <cstring> // std::memcpy
-#include <memory>  // std::addressof
+#include <cstdint>     // std::uint8_t, std::uint16_t, etc
+#include <cstring>     // std::memcpy
+#include <memory>      // std::addressof
+#include <type_traits> // std::is_trivially_copyable
 
 namespace bit {
   namespace memory {
@@ -20,6 +21,8 @@ namespace bit {
     //-------------------------------------------------------------------------
 
     /// \brief Stores an arbitrary type \p T into unaligned memory
+    ///
+    /// \pre \c std::is_trivially_copyable<T>::value is \c true
     ///
     /// \param p the memory to store into
     /// \param val the value to store
@@ -37,6 +40,8 @@ namespace bit {
     ///       pointing to potentially unsafe memory. Ideally, this function
     ///       should only be used to load fundamental types, or simple
     ///       pod/aggregate types.
+    ///
+    /// \pre \c std::is_trivially_copyable<T>::value is \c true
     ///
     /// \param p pointer to the memory to load from
     /// \return the type \p T

--- a/src/bit/memory/block_allocators/virtual_block_allocator.cpp
+++ b/src/bit/memory/block_allocators/virtual_block_allocator.cpp
@@ -53,14 +53,14 @@ bit::memory::owner<bit::memory::memory_block>
     return m_cache.request_block();
   }
 
-  if( (static_cast<std::size_t>(m_active_page) < m_pages) ) {
-    auto v = static_cast<byte_t*>(m_memory) + (m_active_page++ * virtual_memory_page_size());
-    auto p = virtual_memory_commit( v, 1 );
-
-    return {p, virtual_memory_page_size()};
+  if( (static_cast<std::size_t>(m_active_page) >= m_pages) ) {
+    return nullblock;
   }
 
-  return nullblock;
+  auto v = static_cast<byte_t*>(m_memory) + (m_active_page++ * virtual_memory_page_size());
+  auto p = virtual_memory_commit( v, 1 );
+
+  return {p, virtual_memory_page_size()};
 }
 
 void bit::memory::virtual_block_allocator::deallocate_block( owner<memory_block> block )
@@ -76,6 +76,7 @@ void bit::memory::virtual_block_allocator::deallocate_block( owner<memory_block>
 std::size_t bit::memory::virtual_block_allocator::next_block_size()
   const noexcept
 {
+  if( (static_cast<std::size_t>(m_active_page) >= m_pages) ) return 0;
   return virtual_memory_page_size();
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(source_files
   bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
   bit/memory/block_allocators/growing_malloc_block_allocator.test.cpp
   bit/memory/block_allocators/growing_new_block_allocator.test.cpp
+  bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp
   bit/memory/block_allocators/new_block_allocator.test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(source_files
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp
   bit/memory/block_allocators/new_block_allocator.test.cpp
+  bit/memory/block_allocators/static_block_allocator.test.cpp
   bit/memory/block_allocators/virtual_block_allocator.test.cpp
 
   ${platform_source_files}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,13 @@ set(source_files
   ${platform_source_files}
 )
 
+# Unfortunately, certain AppleClang versions don't support 'thread_local'; so to
+# avoid failing independence tests, they have been appended here
+if( NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
+  list(APPEND source_files bit/memory/block_allocators/thread_local_block_allocator.test.cpp)
+endif()
+
+
 add_executable(bit_memory_test ${source_files})
 
 target_link_libraries(bit_memory_test PRIVATE "bit::memory" "philsquared::Catch")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,8 +19,9 @@ set(source_files
   bit/memory/allocators/any_allocator.test.cpp
 
   # Block Allocators
-  bit/memory/block_allocators/any_block_allocator.test.cpp
   bit/memory/block_allocators/aligned_block_allocator.test.cpp
+  bit/memory/block_allocators/any_block_allocator.test.cpp
+  bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp
   bit/memory/block_allocators/new_block_allocator.test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(source_files
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp
   bit/memory/block_allocators/new_block_allocator.test.cpp
+  bit/memory/block_allocators/stack_block_allocator.test.cpp
   bit/memory/block_allocators/static_block_allocator.test.cpp
   bit/memory/block_allocators/virtual_block_allocator.test.cpp
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(source_files
   bit/memory/block_allocators/aligned_block_allocator.test.cpp
   bit/memory/block_allocators/any_block_allocator.test.cpp
   bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+  bit/memory/block_allocators/growing_malloc_block_allocator.test.cpp
   bit/memory/block_allocators/growing_new_block_allocator.test.cpp
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(source_files
 
   # Block Allocators
   bit/memory/block_allocators/any_block_allocator.test.cpp
+  bit/memory/block_allocators/aligned_block_allocator.test.cpp
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp
   bit/memory/block_allocators/new_block_allocator.test.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(source_files
   bit/memory/block_allocators/aligned_block_allocator.test.cpp
   bit/memory/block_allocators/any_block_allocator.test.cpp
   bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+  bit/memory/block_allocators/growing_new_block_allocator.test.cpp
   bit/memory/block_allocators/null_block_allocator.test.cpp
   bit/memory/block_allocators/malloc_block_allocator.test.cpp
   bit/memory/block_allocators/new_block_allocator.test.cpp

--- a/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
@@ -185,7 +185,8 @@ TEST_CASE("cached_aligned_block_allocator<block_size,align>" "[resource manageme
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = (block != bit::memory::nullblock);
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
@@ -1,0 +1,239 @@
+/**
+ * \file aligned_block_allocator.test.cpp
+ *
+ * \brief Unit tests for the aligned_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/aligned_block_allocator.hpp>
+#include <bit/memory/concepts/Stateless.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+#include <bit/memory/pointer_utilities.hpp> // align_of
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type              = bit::memory::aligned_block_allocator<64,64>;
+using named_static_type        = bit::memory::named_aligned_block_allocator<64,64>;
+using cached_static_type       = bit::memory::cached_aligned_block_allocator<64,64>;
+using named_cached_static_type = bit::memory::named_cached_aligned_block_allocator<64,64>;
+
+using dynamic_type              = bit::memory::dynamic_aligned_block_allocator;
+using named_dynamic_type        = bit::memory::named_dynamic_aligned_block_allocator;
+using cached_dynamic_type       = bit::memory::cached_dynamic_aligned_block_allocator;
+using named_cached_dynamic_type = bit::memory::named_cached_dynamic_aligned_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<cached_static_type>::value,
+               "cached static malloc allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_cached_static_type>::value,
+               "named cached static malloc block allocator must be a block allocator" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( bit::memory::is_block_allocator<dynamic_type>::value,
+               "dynamic malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_dynamic_type>::value,
+               "named dynamic malloc block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<cached_dynamic_type>::value,
+               "cached dynamic malloc block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value,
+               "named cached dynamic cached malloc block allocator must be a block allocator");
+
+//=============================================================================
+
+static_assert( bit::memory::is_stateless<static_type>::value,
+               "static malloc block allocator must be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_static_type>::value,
+               "named static malloc block allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<cached_static_type>::value,
+               "cached static malloc allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_cached_static_type>::value,
+               "named cached static malloc block allocator cannot be stateless" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( !bit::memory::is_stateless<dynamic_type>::value,
+               "dynamic malloc block allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_dynamic_type>::value,
+               "named dynamic malloc block allocator cannot be stateless");
+
+static_assert( !bit::memory::is_stateless<cached_dynamic_type>::value,
+               "cached dynamic malloc block allocator cannot be stateless");
+
+static_assert( !bit::memory::is_stateless<named_cached_dynamic_type>::value,
+               "named cached dynamic cached malloc block allocator cannot be stateless");
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// aligned_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("aligned_block_allocator<block_size,align>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  static constexpr auto align      = 1024;
+  auto block_allocator = bit::memory::aligned_block_allocator<block_size,align>();
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Allocates block aligned to at least 'align'")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( bit::memory::align_of(block.data()) >= align );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+// cached_aligned_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("cached_aligned_block_allocator<block_size,align>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  static constexpr auto align      = 1024;
+  auto block_allocator = bit::memory::cached_aligned_block_allocator<block_size,align>{};
+
+  //---------------------------------------------------------------------------
+
+  // block allocators will attempt to reuse deallocated blocks first, before
+  // allocating a new block
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Allocates block aligned to at least 'align'")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( bit::memory::align_of(block.data()) >= align );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+

--- a/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
@@ -114,7 +114,8 @@ TEST_CASE("aligned_block_allocator<block_size,align>" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
@@ -59,8 +59,12 @@ static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value
 
 //=============================================================================
 
+#ifdef _MSC_VER // MSVC fails to determine that this code is actually stateless
+
 static_assert( bit::memory::is_stateless<static_type>::value,
                "static malloc block allocator must be stateless" );
+
+#endif
 
 static_assert( !bit::memory::is_stateless<named_static_type>::value,
                "named static malloc block allocator cannot be stateless" );

--- a/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
@@ -59,7 +59,7 @@ static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value
 
 //=============================================================================
 
-#ifdef _MSC_VER // MSVC fails to determine that this code is actually stateless
+#ifndef _MSC_VER // MSVC fails to determine that this code is actually stateless
 
 static_assert( bit::memory::is_stateless<static_type>::value,
                "static malloc block allocator must be stateless" );

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -235,7 +235,8 @@ TEST_CASE("cached_growing_aligned_block_allocator<block_size,align>" "[resource 
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -1,0 +1,318 @@
+/**
+ * \file growing_aligned_block_allocator.test.cpp
+ *
+ * \brief Unit tests for the growing_aligned_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/growing_aligned_block_allocator.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+#include <bit/memory/pointer_utilities.hpp> // align_of
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type              = bit::memory::growing_aligned_block_allocator<64,64>;
+using named_static_type        = bit::memory::named_growing_aligned_block_allocator<64,64>;
+using cached_static_type       = bit::memory::cached_growing_aligned_block_allocator<64,64>;
+using named_cached_static_type = bit::memory::named_cached_growing_aligned_block_allocator<64,64>;
+
+using dynamic_type              = bit::memory::dynamic_growing_aligned_block_allocator;
+using named_dynamic_type        = bit::memory::named_dynamic_growing_aligned_block_allocator;
+using cached_dynamic_type       = bit::memory::cached_dynamic_growing_aligned_block_allocator;
+using named_cached_dynamic_type = bit::memory::named_cached_dynamic_growing_aligned_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static growing aligned block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static growing aligned block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<cached_static_type>::value,
+               "cached static growing aligned allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_cached_static_type>::value,
+               "named cached growing aligned malloc block allocator must be a block allocator" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( bit::memory::is_block_allocator<dynamic_type>::value,
+               "dynamic growing aligned block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_dynamic_type>::value,
+               "named dynamic growing aligned block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<cached_dynamic_type>::value,
+               "cached dynamic growing aligned block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value,
+               "named cached dynamic cached growing aligned block allocator must be a block allocator");
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// growing_aligned_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource management]")
+{
+  static constexpr auto block_size  = 1024;
+  static constexpr auto align       = 1024;
+  static constexpr auto growths     = 3;
+  auto block_allocator = bit::memory::growing_aligned_block_allocator<block_size,align>{growths};
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Allocates block aligned to at least 'align'")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( bit::memory::align_of(block.data()) >= align );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block grows with each allocation")
+  {
+    auto block = block_allocator.allocate_block();
+
+    SECTION("Lists next_block_size as 2*'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == (2 * block_size) );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Allocates block aligned to at least 'align'")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( bit::memory::align_of(block.data()) >= align );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 2*'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == (2 * block_size) );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Allocates block aligned to at least 'align'")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( bit::memory::align_of(block.data()) >= align );
+
+      block_allocator.deallocate_block( block );
+    }
+
+
+    block_allocator.deallocate_block(block);
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block caps size at growths ^ rate * block_size")
+  {
+    auto allocated_blocks = std::array<bit::memory::memory_block,growths>{};
+
+    for( auto& block : allocated_blocks ) {
+      block = block_allocator.allocate_block();
+    }
+
+    SECTION("Lists next_block_size as 2*'block_size'")
+    {
+      const auto multiplyer = 1 << growths;
+      const auto size       = block_allocator.next_block_size();
+
+      REQUIRE( size == (multiplyer * block_size) );
+    }
+
+    SECTION("Allocates block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      SECTION("Block is non-null")
+      {
+        REQUIRE( block != bit::memory::nullblock );
+      }
+
+      SECTION("Block size is ")
+      {
+        const auto multiplyer = 1 << growths;
+
+        REQUIRE( block != bit::memory::nullblock );
+      }
+
+      SECTION("Block is aligned to at least 'align'")
+      {
+        REQUIRE( bit::memory::align_of(block.data()) >= align );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+
+    for( auto& block : allocated_blocks ) {
+      block_allocator.deallocate_block(block);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+// cached_growing_aligned_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("cached_growing_aligned_block_allocator<block_size,align>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  static constexpr auto align      = 1024;
+  static constexpr auto growths    = 3;
+  auto block_allocator = bit::memory::cached_growing_aligned_block_allocator<block_size,align>{growths};
+
+  //---------------------------------------------------------------------------
+
+  // block allocators will attempt to reuse deallocated blocks first, before
+  // allocating a new block
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Allocates block aligned to at least 'align'")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( bit::memory::align_of(block.data()) >= align );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -67,8 +67,8 @@ static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value
 
 TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource management]")
 {
-  static constexpr auto block_size  = 1024;
   static constexpr auto align       = 1024;
+  static constexpr auto block_size  = 1024;
   static constexpr auto growths     = 3u;
   auto block_allocator = bit::memory::growing_aligned_block_allocator<block_size,align>{growths};
 
@@ -148,7 +148,7 @@ TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource managem
       block = block_allocator.allocate_block();
     }
 
-    SECTION("Lists next_block_size as 2*'block_size'")
+    SECTION("Lists next_block_size as multiplyer*'block_size'")
     {
       const auto multiplyer = 1 << growths;
       const auto size       = block_allocator.next_block_size();
@@ -162,14 +162,8 @@ TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource managem
 
       SECTION("Block is non-null")
       {
-        REQUIRE( block != bit::memory::nullblock );
-      }
-
-      SECTION("Block size is ")
-      {
-        const auto multiplyer = 1 << growths;
-
-        REQUIRE( block != bit::memory::nullblock );
+        auto success = (block != bit::memory::nullblock);
+        REQUIRE( success );
       }
 
       SECTION("Block is aligned to at least 'align'")

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -69,7 +69,7 @@ TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource managem
 {
   static constexpr auto block_size  = 1024;
   static constexpr auto align       = 1024;
-  static constexpr auto growths     = 3;
+  static constexpr auto growths     = 3u;
   auto block_allocator = bit::memory::growing_aligned_block_allocator<block_size,align>{growths};
 
   //---------------------------------------------------------------------------
@@ -212,7 +212,7 @@ TEST_CASE("cached_growing_aligned_block_allocator<block_size,align>" "[resource 
 {
   static constexpr auto block_size = 1024;
   static constexpr auto align      = 1024;
-  static constexpr auto growths    = 3;
+  static constexpr auto growths    = 3u;
   auto block_allocator = bit::memory::cached_growing_aligned_block_allocator<block_size,align>{growths};
 
   //---------------------------------------------------------------------------

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -87,7 +87,8 @@ TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource managem
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }
@@ -119,7 +120,8 @@ TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource managem
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }
@@ -132,32 +134,6 @@ TEST_CASE("growing_aligned_block_allocator<block_size,align>" "[resource managem
 
       block_allocator.deallocate_block( block );
     }
-
-    SECTION("Lists next_block_size as 2*'block_size'")
-    {
-      const auto size = block_allocator.next_block_size();
-
-      REQUIRE( size == (2 * block_size) );
-    }
-
-    SECTION("Allocates non-null block")
-    {
-      auto block = block_allocator.allocate_block();
-
-      REQUIRE( block != bit::memory::nullblock );
-
-      block_allocator.deallocate_block( block );
-    }
-
-    SECTION("Allocates block aligned to at least 'align'")
-    {
-      auto block = block_allocator.allocate_block();
-
-      REQUIRE( bit::memory::align_of(block.data()) >= align );
-
-      block_allocator.deallocate_block( block );
-    }
-
 
     block_allocator.deallocate_block(block);
   }

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -13,6 +13,7 @@
 #include <catch.hpp>
 
 #include <cstring> // std::memset
+#include <array> // std::array
 
 //=============================================================================
 // Static Requirements

--- a/test/bit/memory/block_allocators/growing_malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_malloc_block_allocator.test.cpp
@@ -1,0 +1,255 @@
+/**
+ * \file growing_malloc_block_allocator.test.cpp
+ *
+ * \brief Unit tests for the growing_malloc_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/growing_malloc_block_allocator.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+#include <array> // std::array
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type              = bit::memory::growing_malloc_block_allocator<64>;
+using named_static_type        = bit::memory::named_growing_malloc_block_allocator<64>;
+using cached_static_type       = bit::memory::cached_growing_malloc_block_allocator<64>;
+using named_cached_static_type = bit::memory::named_cached_growing_malloc_block_allocator<64>;
+
+using dynamic_type              = bit::memory::dynamic_growing_malloc_block_allocator;
+using named_dynamic_type        = bit::memory::named_dynamic_growing_malloc_block_allocator;
+using cached_dynamic_type       = bit::memory::cached_dynamic_growing_malloc_block_allocator;
+using named_cached_dynamic_type = bit::memory::named_cached_dynamic_growing_malloc_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static growing malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static growing malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<cached_static_type>::value,
+               "cached static growing malloc allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_cached_static_type>::value,
+               "named cached growing malloc malloc block allocator must be a block allocator" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( bit::memory::is_block_allocator<dynamic_type>::value,
+               "dynamic growing malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_dynamic_type>::value,
+               "named dynamic growing malloc block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<cached_dynamic_type>::value,
+               "cached dynamic growing malloc block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value,
+               "named cached dynamic cached growing malloc block allocator must be a block allocator");
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// growing_malloc_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("growing_malloc_block_allocator<block_size>" "[resource management]")
+{
+  static constexpr auto block_size  = 1024;
+  static constexpr auto growths     = 3u;
+  auto block_allocator = bit::memory::growing_malloc_block_allocator<block_size>{growths};
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block grows with each allocation")
+  {
+    auto block = block_allocator.allocate_block();
+
+    SECTION("Lists next_block_size as 2*'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == (2 * block_size) );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    block_allocator.deallocate_block(block);
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block caps size at growths ^ rate * block_size")
+  {
+    auto allocated_blocks = std::array<bit::memory::memory_block,growths>{};
+
+    for( auto& block : allocated_blocks ) {
+      block = block_allocator.allocate_block();
+    }
+
+    SECTION("Lists next_block_size as multiplyer*'block_size'")
+    {
+      const auto multiplyer = 1 << growths;
+      const auto size       = block_allocator.next_block_size();
+
+      REQUIRE( size == (multiplyer * block_size) );
+    }
+
+    SECTION("Allocates block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      SECTION("Block is non-null")
+      {
+        auto success = (block != bit::memory::nullblock);
+        REQUIRE( success );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+
+    for( auto& block : allocated_blocks ) {
+      block_allocator.deallocate_block(block);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+// cached_growing_malloc_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("cached_growing_malloc_block_allocator<block_size>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  static constexpr auto growths    = 3u;
+  auto block_allocator = bit::memory::cached_growing_malloc_block_allocator<block_size>{growths};
+
+  //---------------------------------------------------------------------------
+
+  // block allocators will attempt to reuse deallocated blocks first, before
+  // allocating a new block
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}

--- a/test/bit/memory/block_allocators/growing_new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_new_block_allocator.test.cpp
@@ -1,0 +1,256 @@
+/**
+ * \file growing_new_block_allocator.test.cpp
+ *
+ * \brief Unit tests for the growing_new_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/growing_new_block_allocator.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+#include <array> // std::array
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type              = bit::memory::growing_new_block_allocator<64>;
+using named_static_type        = bit::memory::named_growing_new_block_allocator<64>;
+using cached_static_type       = bit::memory::cached_growing_new_block_allocator<64>;
+using named_cached_static_type = bit::memory::named_cached_growing_new_block_allocator<64>;
+
+using dynamic_type              = bit::memory::dynamic_growing_new_block_allocator;
+using named_dynamic_type        = bit::memory::named_dynamic_growing_new_block_allocator;
+using cached_dynamic_type       = bit::memory::cached_dynamic_growing_new_block_allocator;
+using named_cached_dynamic_type = bit::memory::named_cached_dynamic_growing_new_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static growing new block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static growing new block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<cached_static_type>::value,
+               "cached static growing new allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_cached_static_type>::value,
+               "named cached growing new malloc block allocator must be a block allocator" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( bit::memory::is_block_allocator<dynamic_type>::value,
+               "dynamic growing new block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_dynamic_type>::value,
+               "named dynamic growing new block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<cached_dynamic_type>::value,
+               "cached dynamic growing new block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value,
+               "named cached dynamic cached growing new block allocator must be a block allocator");
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// growing_new_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("growing_new_block_allocator<block_size>" "[resource management]")
+{
+  static constexpr auto block_size  = 1024;
+  static constexpr auto growths     = 3u;
+  auto block_allocator = bit::memory::growing_new_block_allocator<block_size>{growths};
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block grows with each allocation")
+  {
+    auto block = block_allocator.allocate_block();
+
+    SECTION("Lists next_block_size as 2*'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == (2 * block_size) );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    block_allocator.deallocate_block(block);
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block caps size at growths ^ rate * block_size")
+  {
+    auto allocated_blocks = std::array<bit::memory::memory_block,growths>{};
+
+    for( auto& block : allocated_blocks ) {
+      block = block_allocator.allocate_block();
+    }
+
+    SECTION("Lists next_block_size as multiplyer*'block_size'")
+    {
+      const auto multiplyer = 1 << growths;
+      const auto size       = block_allocator.next_block_size();
+
+      REQUIRE( size == (multiplyer * block_size) );
+    }
+
+    SECTION("Allocates block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      SECTION("Block is non-null")
+      {
+        auto success = (block != bit::memory::nullblock);
+        REQUIRE( success );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+
+    for( auto& block : allocated_blocks ) {
+      block_allocator.deallocate_block(block);
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+// cached_growing_new_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("cached_growing_new_block_allocator<block_size>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  static constexpr auto growths    = 3u;
+  auto block_allocator = bit::memory::cached_growing_new_block_allocator<block_size>{growths};
+
+  //---------------------------------------------------------------------------
+
+  // block allocators will attempt to reuse deallocated blocks first, before
+  // allocating a new block
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+

--- a/test/bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
@@ -1,0 +1,167 @@
+/**
+ * \file growing_virtual_block_allocator.test.cpp
+ *
+ * \brief Unit tests for the growing_virtual_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/growing_virtual_block_allocator.hpp>
+#include <bit/memory/virtual_memory.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+#include <array> // std::array
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type       = bit::memory::growing_virtual_block_allocator;
+using named_static_type = bit::memory::named_growing_virtual_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "virtual block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named virtual block allocator must be a block allocator" );
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// growing_virtual_block_allocator
+//-----------------------------------------------------------------------------
+
+TEST_CASE("growing_virtual_block_allocator" "[resource management]")
+{
+  static constexpr auto blocks     = 4u;
+  static const     auto block_size = bit::memory::virtual_memory_page_size();
+  auto block_allocator = bit::memory::growing_virtual_block_allocator{blocks};
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block without blocks available")
+  {
+    auto allocated_blocks = std::array<bit::memory::memory_block,3>{};
+    for( auto i = 0; i < 3; ++i ) {
+      allocated_blocks[i] = block_allocator.allocate_block();
+    }
+
+    SECTION("Lists next_block_size as 0")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == 0 );
+    }
+
+    SECTION("Allocates a null block")
+    {
+      const auto null_block = block_allocator.allocate_block();
+
+      auto success = null_block == bit::memory::nullblock;
+      REQUIRE( success );
+    }
+
+    for( auto i = 0; i < blocks; ++i ) {
+      block_allocator.deallocate_block( allocated_blocks[i] );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  // This test only works because 'static_block_allocator<N,1>' holds a single
+  // block; otherwise the order of reuse is implementation defined.
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}

--- a/test/bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
@@ -13,7 +13,7 @@
 #include <catch.hpp>
 
 #include <cstring> // std::memset
-#include <array> // std::array
+#include <array>   // std::array
 
 //=============================================================================
 // Static Requirements
@@ -90,7 +90,7 @@ TEST_CASE("growing_virtual_block_allocator" "[resource management]")
       REQUIRE( success );
     }
 
-    for( auto i = 0; i < blocks; ++i ) {
+    for( auto i = 0; i < 3; ++i ) {
       block_allocator.deallocate_block( allocated_blocks[i] );
     }
   }

--- a/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
@@ -12,6 +12,8 @@
 
 #include <catch.hpp>
 
+#include <cstring> // std::memset
+
 //=============================================================================
 // Static Requirements
 //=============================================================================
@@ -87,35 +89,101 @@ static_assert( !bit::memory::is_stateless<named_cached_dynamic_type>::value,
 //=============================================================================
 
 //-----------------------------------------------------------------------------
-// Block Allocations
+// malloc_block_allocator<1024>
 //-----------------------------------------------------------------------------
 
-TEST_CASE("malloc_block_allocator::allocate_block()")
+TEST_CASE("malloc_block_allocator<1024>" "[resource management]")
 {
   static constexpr auto block_size = 1024;
-
   auto block_allocator = bit::memory::malloc_block_allocator<block_size>();
 
-  SECTION("Allocates a memory block")
-  {
-    auto block = block_allocator.allocate_block();
+  //---------------------------------------------------------------------------
 
-    SECTION("Block is not null")
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
     {
-      auto succeeds = block != bit::memory::nullblock;
-      REQUIRE( succeeds );
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
     }
 
-    SECTION("Size is specified by constructor")
+    SECTION("Allocates non-null block")
     {
-      REQUIRE( block.size() == block_size );
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
     }
   }
-}
 
-//-----------------------------------------------------------------------------
+  //---------------------------------------------------------------------------
 
-TEST_CASE("malloc_block_allocator::deallocate_block( owner<memory_block> )")
-{
+  // block allocators will attempt to reuse deallocated blocks first, before
+  // allocating a new block
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
 
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
 }

--- a/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
@@ -173,7 +173,8 @@ TEST_CASE("cached_malloc_block_allocator<1024>" "[resource management]")
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
@@ -120,6 +120,34 @@ TEST_CASE("malloc_block_allocator<1024>" "[resource management]")
 
   //---------------------------------------------------------------------------
 
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+// cached_malloc_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("cached_malloc_block_allocator<1024>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  auto block_allocator = bit::memory::cached_malloc_block_allocator<block_size>{};
+
+  //---------------------------------------------------------------------------
+
   // block allocators will attempt to reuse deallocated blocks first, before
   // allocating a new block
   SECTION("allocate_block reuses previously deallocated block")

--- a/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
@@ -112,7 +112,8 @@ TEST_CASE("malloc_block_allocator<1024>" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
@@ -7,16 +7,93 @@
  */
 
 #include <bit/memory/block_allocators/malloc_block_allocator.hpp>
+#include <bit/memory/concepts/Stateless.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
 
 #include <catch.hpp>
 
-//----------------------------------------------------------------------------
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type              = bit::memory::malloc_block_allocator<64>;
+using named_static_type        = bit::memory::named_malloc_block_allocator<64>;
+using cached_static_type       = bit::memory::cached_malloc_block_allocator<64>;
+using named_cached_static_type = bit::memory::named_cached_malloc_block_allocator<64>;
+
+using dynamic_type              = bit::memory::dynamic_malloc_block_allocator;
+using named_dynamic_type        = bit::memory::named_dynamic_malloc_block_allocator;
+using cached_dynamic_type       = bit::memory::cached_dynamic_malloc_block_allocator;
+using named_cached_dynamic_type = bit::memory::named_cached_dynamic_malloc_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<cached_static_type>::value,
+               "cached static malloc allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_cached_static_type>::value,
+               "named cached static malloc block allocator must be a block allocator" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( bit::memory::is_block_allocator<dynamic_type>::value,
+               "dynamic malloc block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_dynamic_type>::value,
+               "named dynamic malloc block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<cached_dynamic_type>::value,
+               "cached dynamic malloc block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value,
+               "named cached dynamic cached malloc block allocator must be a block allocator");
+
+//=============================================================================
+
+static_assert( bit::memory::is_stateless<static_type>::value,
+               "static malloc block allocator must be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_static_type>::value,
+               "named static malloc block allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<cached_static_type>::value,
+               "cached static malloc allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_cached_static_type>::value,
+               "named cached static malloc block allocator cannot be stateless" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( !bit::memory::is_stateless<dynamic_type>::value,
+               "dynamic malloc block allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_dynamic_type>::value,
+               "named dynamic malloc block allocator cannot be stateless");
+
+static_assert( !bit::memory::is_stateless<cached_dynamic_type>::value,
+               "cached dynamic malloc block allocator cannot be stateless");
+
+static_assert( !bit::memory::is_stateless<named_cached_dynamic_type>::value,
+               "named cached dynamic cached malloc block allocator cannot be stateless");
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
 // Block Allocations
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 TEST_CASE("malloc_block_allocator::allocate_block()")
 {
-  static const auto block_size = 1024;
+  static constexpr auto block_size = 1024;
+
   auto block_allocator = bit::memory::malloc_block_allocator<block_size>();
 
   SECTION("Allocates a memory block")
@@ -36,9 +113,9 @@ TEST_CASE("malloc_block_allocator::allocate_block()")
   }
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 TEST_CASE("malloc_block_allocator::deallocate_block( owner<memory_block> )")
 {
-  //
+
 }

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -90,7 +90,7 @@ static_assert( !bit::memory::is_stateless<named_cached_dynamic_type>::value,
 // Block Allocations
 //-----------------------------------------------------------------------------
 
-TEST_CASE("new_block_allocator::allocate_block<1024>()")
+TEST_CASE("new_block_allocator::allocate_block()")
 {
   static const auto block_size = 1024;
   auto block_allocator = bit::memory::new_block_allocator<block_size>();

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -112,7 +112,8 @@ TEST_CASE("new_block_allocator<1024>" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -10,6 +10,8 @@
 #include <bit/memory/concepts/Stateless.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>
 
+#include <cstring>
+
 #include <catch.hpp>
 
 //=============================================================================
@@ -87,34 +89,101 @@ static_assert( !bit::memory::is_stateless<named_cached_dynamic_type>::value,
 //=============================================================================
 
 //-----------------------------------------------------------------------------
-// Block Allocations
+// new_block_allocator<1024>
 //-----------------------------------------------------------------------------
 
-TEST_CASE("new_block_allocator::allocate_block()")
+TEST_CASE("new_block_allocator<1024>" "[resource management]")
 {
-  static const auto block_size = 1024;
+  static constexpr auto block_size = 1024;
   auto block_allocator = bit::memory::new_block_allocator<block_size>();
 
-  SECTION("Allocates a memory block")
-  {
-    auto block = block_allocator.allocate_block();
+  //---------------------------------------------------------------------------
 
-    SECTION("Block is not null")
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
     {
-      auto succeeds = block != bit::memory::nullblock;
-      REQUIRE( succeeds );
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
     }
 
-    SECTION("Size is specified by constructor")
+    SECTION("Allocates non-null block")
     {
-      REQUIRE( block.size() == block_size );
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
     }
   }
-}
 
-//-----------------------------------------------------------------------------
+  //---------------------------------------------------------------------------
 
-TEST_CASE("new_block_allocator::deallocate_block( owner<memory_block> )")
-{
-  //
+  // block allocators will attempt to reuse deallocated blocks first, before
+  // allocating a new block
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
 }

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -7,12 +7,88 @@
  */
 
 #include <bit/memory/block_allocators/new_block_allocator.hpp>
+#include <bit/memory/concepts/Stateless.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
 
 #include <catch.hpp>
 
-//----------------------------------------------------------------------------
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type              = bit::memory::new_block_allocator<64>;
+using named_static_type        = bit::memory::named_new_block_allocator<64>;
+using cached_static_type       = bit::memory::cached_new_block_allocator<64>;
+using named_cached_static_type = bit::memory::named_cached_new_block_allocator<64>;
+
+using dynamic_type              = bit::memory::dynamic_new_block_allocator;
+using named_dynamic_type        = bit::memory::named_dynamic_new_block_allocator;
+using cached_dynamic_type       = bit::memory::cached_dynamic_new_block_allocator;
+using named_cached_dynamic_type = bit::memory::named_cached_dynamic_new_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static new block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static new block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<cached_static_type>::value,
+               "cached static new allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_cached_static_type>::value,
+               "named cached static new block allocator must be a block allocator" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( bit::memory::is_block_allocator<dynamic_type>::value,
+               "dynamic new block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_dynamic_type>::value,
+               "named dynamic new block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<cached_dynamic_type>::value,
+               "cached dynamic new block allocator must be a block allocator");
+
+static_assert( bit::memory::is_block_allocator<named_cached_dynamic_type>::value,
+               "named cached dynamic cached new block allocator must be a block allocator");
+
+//=============================================================================
+
+static_assert( bit::memory::is_stateless<static_type>::value,
+               "static new block allocator must be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_static_type>::value,
+               "named static new block allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<cached_static_type>::value,
+               "cached static new allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_cached_static_type>::value,
+               "named cached static new block allocator cannot be stateless" );
+
+//-----------------------------------------------------------------------------
+
+static_assert( !bit::memory::is_stateless<dynamic_type>::value,
+               "dynamic new block allocator cannot be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_dynamic_type>::value,
+               "named dynamic new block allocator cannot be stateless");
+
+static_assert( !bit::memory::is_stateless<cached_dynamic_type>::value,
+               "cached dynamic new block allocator cannot be stateless");
+
+static_assert( !bit::memory::is_stateless<named_cached_dynamic_type>::value,
+               "named cached dynamic cached new block allocator cannot be stateless");
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
 // Block Allocations
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 TEST_CASE("new_block_allocator::allocate_block<1024>()")
 {
@@ -36,7 +112,7 @@ TEST_CASE("new_block_allocator::allocate_block<1024>()")
   }
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 TEST_CASE("new_block_allocator::deallocate_block( owner<memory_block> )")
 {

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -173,7 +173,8 @@ TEST_CASE("cached_new_block_allocator<1024>" "[resource management]")
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -120,6 +120,34 @@ TEST_CASE("new_block_allocator<1024>" "[resource management]")
 
   //---------------------------------------------------------------------------
 
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}
+
+//-----------------------------------------------------------------------------
+// cached_new_block_allocator<1024>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("cached_new_block_allocator<1024>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  auto block_allocator = bit::memory::cached_new_block_allocator<block_size>{};
+
+  //---------------------------------------------------------------------------
+
   // block allocators will attempt to reuse deallocated blocks first, before
   // allocating a new block
   SECTION("allocate_block reuses previously deallocated block")

--- a/test/bit/memory/block_allocators/null_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/null_block_allocator.test.cpp
@@ -40,29 +40,24 @@ static_assert( !bit::memory::is_stateless<named_static_type>::value,
 //=============================================================================
 
 //-----------------------------------------------------------------------------
-// Block Allocations
+// null_block_allocator
 //-----------------------------------------------------------------------------
 
-TEST_CASE("null_block_allocator::allocate_block()")
+TEST_CASE("null_block_allocator" "[resource management]")
 {
-  auto block_allocator = bit::memory::null_block_allocator();
+  auto block_allocator = bit::memory::null_block_allocator{};
 
-  SECTION("Allocates a memory block")
+  SECTION("next_block_size is always 0")
+  {
+    auto size = block_allocator.next_block_size();
+
+    REQUIRE( size == 0 );
+  }
+
+  SECTION("Allocates null memory blocks")
   {
     auto block = block_allocator.allocate_block();
 
-    SECTION("Block is null")
-    {
-      auto succeeds = block == bit::memory::nullblock;
-      REQUIRE( succeeds );
-    }
+    REQUIRE( block == bit::memory::nullblock );
   }
-}
-
-//-----------------------------------------------------------------------------
-
-TEST_CASE("null_block_allocator::deallocate_block( owner<memory_block> )")
-{
-  // deallocate does nothing for null_block_allocator
-  REQUIRE( true );
 }

--- a/test/bit/memory/block_allocators/null_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/null_block_allocator.test.cpp
@@ -7,12 +7,41 @@
  */
 
 #include <bit/memory/block_allocators/null_block_allocator.hpp>
+#include <bit/memory/concepts/Stateless.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
 
 #include <catch.hpp>
 
-//----------------------------------------------------------------------------
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type       = bit::memory::null_block_allocator;
+using named_static_type = bit::memory::named_null_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "null block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named null block allocator must be a block allocator" );
+
+//=============================================================================
+
+static_assert( bit::memory::is_stateless<static_type>::value,
+               "null block allocator must be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_static_type>::value,
+               "named null block allocator cannot be stateless stateless" );
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
 // Block Allocations
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 TEST_CASE("null_block_allocator::allocate_block()")
 {
@@ -30,7 +59,7 @@ TEST_CASE("null_block_allocator::allocate_block()")
   }
 }
 
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 
 TEST_CASE("null_block_allocator::deallocate_block( owner<memory_block> )")
 {

--- a/test/bit/memory/block_allocators/null_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/null_block_allocator.test.cpp
@@ -58,6 +58,7 @@ TEST_CASE("null_block_allocator" "[resource management]")
   {
     auto block = block_allocator.allocate_block();
 
-    REQUIRE( block == bit::memory::nullblock );
+    auto success = block == bit::memory::nullblock;
+    REQUIRE( success );
   }
 }

--- a/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
@@ -56,7 +56,8 @@ TEST_CASE("stack_block_allocator<1024,1>" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }
@@ -79,7 +80,8 @@ TEST_CASE("stack_block_allocator<1024,1>" "[resource management]")
     {
       const auto null_block = block_allocator.allocate_block();
 
-      REQUIRE( null_block == bit::memory::nullblock );
+      auto success = (null_block == bit::memory::nullblock);
+      REQUIRE( success );
     }
 
     block_allocator.deallocate_block( block );

--- a/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
@@ -113,7 +113,8 @@ TEST_CASE("stack_block_allocator<1024,1>" "[resource management]")
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
@@ -1,0 +1,156 @@
+/**
+ * \file stack_block_allocators.test.cpp
+ *
+ * \brief Unit tests for the stack_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/stack_block_allocator.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type       = bit::memory::stack_block_allocator<1>;
+using named_static_type = bit::memory::named_stack_block_allocator<1>;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static block allocator must be a block allocator" );
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// stack_block_allocator<1024,1>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("stack_block_allocator<1024,1>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  bit::memory::stack_block_allocator<block_size,1> block_allocator{};
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block without blocks available")
+  {
+    auto block = block_allocator.allocate_block();
+
+    SECTION("Lists next_block_size as 0")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == 0 );
+    }
+
+    SECTION("Allocates a null block")
+    {
+      const auto null_block = block_allocator.allocate_block();
+
+      REQUIRE( null_block == bit::memory::nullblock );
+    }
+
+    block_allocator.deallocate_block( block );
+  }
+
+  //---------------------------------------------------------------------------
+
+  // This test only works because 'stack_block_allocator<N,1>' holds a single
+  // block; otherwise the order of reuse is implementation defined.
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}

--- a/test/bit/memory/block_allocators/static_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/static_block_allocator.test.cpp
@@ -10,9 +10,9 @@
 #include <bit/memory/concepts/BlockAllocator.hpp>
 #include <bit/memory/concepts/Stateless.hpp>
 
-#include <cstring> // std::memset
-
 #include <catch.hpp>
+
+#include <cstring> // std::memset
 
 //=============================================================================
 // Static Requirements

--- a/test/bit/memory/block_allocators/static_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/static_block_allocator.test.cpp
@@ -65,7 +65,8 @@ TEST_CASE("static_block_allocator<1024,1>" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }
@@ -88,7 +89,8 @@ TEST_CASE("static_block_allocator<1024,1>" "[resource management]")
     {
       const auto null_block = block_allocator.allocate_block();
 
-      REQUIRE( null_block == bit::memory::nullblock );
+      auto success = null_block == bit::memory::nullblock;
+      REQUIRE( success );
     }
 
     block_allocator.deallocate_block( block );

--- a/test/bit/memory/block_allocators/static_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/static_block_allocator.test.cpp
@@ -122,7 +122,8 @@ TEST_CASE("static_block_allocator<1024,1>" "[resource management]")
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/static_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/static_block_allocator.test.cpp
@@ -1,0 +1,165 @@
+/**
+ * \file static_block_allocators.test.cpp
+ *
+ * \brief Unit tests for the static_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/static_block_allocator.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+#include <bit/memory/concepts/Stateless.hpp>
+
+#include <cstring> // std::memset
+
+#include <catch.hpp>
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type       = bit::memory::static_block_allocator<1>;
+using named_static_type = bit::memory::named_static_block_allocator<1>;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static block allocator must be a block allocator" );
+
+//=============================================================================
+
+static_assert( bit::memory::is_stateless<static_type>::value,
+               "static block allocator must be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_static_type>::value,
+               "named static block allocator cannot be stateless" );
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// static_block_allocator<1024,1>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("static_block_allocator<1024,1>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  auto block_allocator = bit::memory::static_block_allocator<block_size,1>();
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block without blocks available")
+  {
+    auto block = block_allocator.allocate_block();
+
+    SECTION("Lists next_block_size as 0")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == 0 );
+    }
+
+    SECTION("Allocates a null block")
+    {
+      const auto null_block = block_allocator.allocate_block();
+
+      REQUIRE( null_block == bit::memory::nullblock );
+    }
+
+    block_allocator.deallocate_block( block );
+  }
+
+  //---------------------------------------------------------------------------
+
+  // This test only works because 'static_block_allocator<N,1>' holds a single
+  // block; otherwise the order of reuse is implementation defined.
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}

--- a/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
@@ -1,0 +1,165 @@
+/**
+* \file thread_local_block_allocators.test.cpp
+ *
+ * \brief Unit tests for the thread_local_block_allocator
+ *
+ * \author Matthew Rodusek (matthew.rodusek@gmail.com)
+ */
+
+#include <bit/memory/block_allocators/thread_local_block_allocator.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
+#include <bit/memory/concepts/Stateless.hpp>
+
+#include <catch.hpp>
+
+#include <cstring> // std::memset
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type       = bit::memory::thread_local_block_allocator<1>;
+using named_static_type = bit::memory::named_thread_local_block_allocator<1>;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "static block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named static block allocator must be a block allocator" );
+
+//=============================================================================
+
+static_assert( bit::memory::is_stateless<static_type>::value,
+               "static block allocator must be stateless" );
+
+static_assert( !bit::memory::is_stateless<named_static_type>::value,
+               "named static block allocator cannot be stateless" );
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// thread_local_block_allocator<1024,1>
+//-----------------------------------------------------------------------------
+
+TEST_CASE("thread_local_block_allocator<1024,1>" "[resource management]")
+{
+  static constexpr auto block_size = 1024;
+  auto block_allocator = bit::memory::thread_local_block_allocator<block_size,1>();
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
+  {
+    SECTION("Lists next_block_size as 'block_size'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
+    }
+
+    SECTION("Allocates non-null block")
+    {
+      auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block without blocks available")
+  {
+    auto block = block_allocator.allocate_block();
+
+    SECTION("Lists next_block_size as 0")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == 0 );
+    }
+
+    SECTION("Allocates a null block")
+    {
+      const auto null_block = block_allocator.allocate_block();
+
+      REQUIRE( null_block == bit::memory::nullblock );
+    }
+
+    block_allocator.deallocate_block( block );
+  }
+
+  //---------------------------------------------------------------------------
+
+  // This test only works because 'thread_local_block_allocator<N,1>' holds a single
+  // block; otherwise the order of reuse is implementation defined.
+  SECTION("allocate_block reuses previously deallocated block")
+  {
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
+  }
+}

--- a/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
@@ -65,7 +65,8 @@ TEST_CASE("thread_local_block_allocator<1024,1>" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }
@@ -88,7 +89,8 @@ TEST_CASE("thread_local_block_allocator<1024,1>" "[resource management]")
     {
       const auto null_block = block_allocator.allocate_block();
 
-      REQUIRE( null_block == bit::memory::nullblock );
+      auto success = null_block == bit::memory::nullblock;
+      REQUIRE( success );
     }
 
     block_allocator.deallocate_block( block );

--- a/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
@@ -122,7 +122,8 @@ TEST_CASE("thread_local_block_allocator<1024,1>" "[resource management]")
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -12,6 +12,8 @@
 
 #include <catch.hpp>
 
+#include <cstring> // std::memset
+
 //=============================================================================
 // Static Requirements
 //=============================================================================
@@ -31,63 +33,131 @@ static_assert( bit::memory::is_block_allocator<named_static_type>::value,
 // Unit Tests
 //=============================================================================
 
-//----------------------------------------------------------------------------
-// Block Allocations
-//----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
+// virtual_block_allocator
+//-----------------------------------------------------------------------------
 
-TEST_CASE("virtual_block_allocator::allocate_block()")
+TEST_CASE("virtual_block_allocator" "[resource management]")
 {
-  auto block_allocator = bit::memory::virtual_block_allocator(3);
+  static constexpr auto blocks     = 3;
+  static const     auto block_size = bit::memory::virtual_memory_page_size();
+  auto block_allocator = bit::memory::virtual_block_allocator{blocks};
 
-  SECTION("Allocates a memory block")
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block with blocks available")
   {
-    auto block = block_allocator.allocate_block();
-
-    SECTION("Block is not null")
+    SECTION("Lists next_block_size as 'block_size'")
     {
-      auto succeeds = block != bit::memory::nullblock;
-      REQUIRE( succeeds );
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == block_size );
     }
 
-    SECTION("Aligns to virtual page boundary")
+    SECTION("Allocates non-null block")
     {
-      auto align = bit::memory::align_of(block.data());
+      auto block = block_allocator.allocate_block();
 
-      REQUIRE( align >= bit::memory::virtual_memory_page_size() );
-    }
+      REQUIRE( block != bit::memory::nullblock );
 
-    SECTION("Size is virtual page size")
-    {
-      REQUIRE( block.size() == bit::memory::virtual_memory_page_size() );
+      block_allocator.deallocate_block( block );
     }
   }
 
-  SECTION("Reallocates previously deallocated blocks")
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block without blocks available")
   {
-    auto block1 = block_allocator.allocate_block();
+    auto allocated_blocks = std::array<bit::memory::memory_block,blocks>{};
+    for( auto i = 0; i < blocks; ++i ) {
+      allocated_blocks[i] = block_allocator.allocate_block();
+    }
 
-    block_allocator.deallocate_block( block1 );
-
-    auto block2 = block_allocator.allocate_block();
-
-    SECTION("Block is the same as previous block")
+    SECTION("Lists next_block_size as 0")
     {
-      REQUIRE( block1 == block2 );
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == 0 );
+    }
+
+    SECTION("Allocates a null block")
+    {
+      const auto null_block = block_allocator.allocate_block();
+
+      REQUIRE( null_block == bit::memory::nullblock );
+    }
+
+    for( auto i = 0; i < blocks; ++i ) {
+      block_allocator.deallocate_block( allocated_blocks[i] );
     }
   }
-}
 
-//----------------------------------------------------------------------------
+  //---------------------------------------------------------------------------
 
-TEST_CASE("virtual_block_allocator::deallocate_block( owner<memory_block> )")
-{
-  auto block_allocator = bit::memory::virtual_block_allocator(3);
-
-  SECTION("Deallocates a previously allocated block")
+  // This test only works because 'static_block_allocator<N,1>' holds a single
+  // block; otherwise the order of reuse is implementation defined.
+  SECTION("allocate_block reuses previously deallocated block")
   {
-    auto block = block_allocator.allocate_block();
-    block_allocator.deallocate_block( std::move(block) );
+    auto p1 = static_cast<void*>(nullptr);
+    auto s1 = static_cast<std::size_t>(0);
+    {
+      auto block = block_allocator.allocate_block();
+      p1 = block.data();
+      s1 = block.size();
+      block_allocator.deallocate_block( block );
+    }
 
-    REQUIRE( true );
+    SECTION("Lists next_block_size as 's1'")
+    {
+      const auto size = block_allocator.next_block_size();
+
+      REQUIRE( size == s1 );
+    }
+
+    SECTION("Allocates a block")
+    {
+      const auto block = block_allocator.allocate_block();
+
+      REQUIRE( block != bit::memory::nullblock );
+
+      block_allocator.deallocate_block( block );
+    }
+
+    SECTION("Reuses previously allocated block")
+    {
+      const auto block = block_allocator.allocate_block();
+      const auto p2 = block.data();
+      const auto s2 = block.size();
+
+      SECTION("Allocates same memory region")
+      {
+        REQUIRE( p1 == p2 );
+      }
+
+      SECTION("Allocates same block size")
+      {
+        REQUIRE( s1 == s2 );
+      }
+
+      block_allocator.deallocate_block( block );
+    }
+  }
+
+  //---------------------------------------------------------------------------
+
+  SECTION("allocate_block creates read/writeable range of memory")
+  {
+    const auto block = block_allocator.allocate_block();
+    auto start = static_cast<unsigned char*>(block.data());
+    auto end   = static_cast<unsigned char*>(block.data()) + block.size();
+
+    // test write
+    std::memset( block.data(), 0x01, block.size() );
+
+    // test read
+    auto sum = 0u;
+    for( ; start != end; ++start ) sum += *start;
+
+    REQUIRE( sum == block.size() );
   }
 }

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -6,11 +6,30 @@
  * \author Matthew Rodusek (matthew.rodusek@gmail.com)
  */
 
-#include <bit/memory/debugging.hpp>
-#include <bit/memory/virtual_memory.hpp>
 #include <bit/memory/block_allocators/virtual_block_allocator.hpp>
+#include <bit/memory/virtual_memory.hpp>
+#include <bit/memory/concepts/BlockAllocator.hpp>
 
 #include <catch.hpp>
+
+//=============================================================================
+// Static Requirements
+//=============================================================================
+
+using static_type       = bit::memory::virtual_block_allocator;
+using named_static_type = bit::memory::named_virtual_block_allocator;
+
+//=============================================================================
+
+static_assert( bit::memory::is_block_allocator<static_type>::value,
+               "virtual block allocator must be a block allocator" );
+
+static_assert( bit::memory::is_block_allocator<named_static_type>::value,
+               "named virtual block allocator must be a block allocator" );
+
+//=============================================================================
+// Unit Tests
+//=============================================================================
 
 //----------------------------------------------------------------------------
 // Block Allocations

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -40,7 +40,7 @@ static_assert( bit::memory::is_block_allocator<named_static_type>::value,
 
 TEST_CASE("virtual_block_allocator" "[resource management]")
 {
-  static constexpr auto blocks     = 3;
+  static constexpr auto blocks     = 3u;
   static const     auto block_size = bit::memory::virtual_memory_page_size();
   auto block_allocator = bit::memory::virtual_block_allocator{blocks};
 

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -121,7 +121,8 @@ TEST_CASE("virtual_block_allocator" "[resource management]")
     {
       const auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -59,7 +59,8 @@ TEST_CASE("virtual_block_allocator" "[resource management]")
     {
       auto block = block_allocator.allocate_block();
 
-      REQUIRE( block != bit::memory::nullblock );
+      auto success = block != bit::memory::nullblock;
+      REQUIRE( success );
 
       block_allocator.deallocate_block( block );
     }
@@ -85,7 +86,8 @@ TEST_CASE("virtual_block_allocator" "[resource management]")
     {
       const auto null_block = block_allocator.allocate_block();
 
-      REQUIRE( null_block == bit::memory::nullblock );
+      auto success = null_block == bit::memory::nullblock;
+      REQUIRE( success );
     }
 
     for( auto i = 0; i < blocks; ++i ) {

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -13,6 +13,7 @@
 #include <catch.hpp>
 
 #include <cstring> // std::memset
+#include <array> // std::array
 
 //=============================================================================
 // Static Requirements


### PR DESCRIPTION
* Added unit tests for block allocators
    * Tests allocation/deallocation
    * Tests caching and reuse of deallocated blocks
    * Tests that allocated memory is read/writeable 
    * Statically validates expectations of classes (concept-constraints)
* Adjusts block allocators to fit expectations
* Adjusts block allocators to compile correctly in MSVC