### PR TITLE
Update header documentation format

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Matthew Rodusek
+Copyright (c) 2018 Matthew Rodusek
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -135,7 +135,7 @@ Visual Studios 2017 is still supported, and will continue to be.
 
 The class is licensed under the [MIT License](http://opensource.org/licenses/MIT):
 
-Copyright &copy; 2017 Matthew Rodusek
+Copyright &copy; 2018 Matthew Rodusek
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/include/bit/memory/adapters/allocator_deleter.hpp
+++ b/include/bit/memory/adapters/allocator_deleter.hpp
@@ -1,11 +1,32 @@
-/**
- * \file allocator_deleter.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of an allocator deleter for use
  *        with smart pointer types
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ADAPTERS_ALLOCATOR_DELETER_HPP
 #define BIT_MEMORY_ADAPTERS_ALLOCATOR_DELETER_HPP
 

--- a/include/bit/memory/adapters/allocator_deleter.hpp
+++ b/include/bit/memory/adapters/allocator_deleter.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ADAPTERS_ALLOCATOR_DELETER_HPP
 #define BIT_MEMORY_ADAPTERS_ALLOCATOR_DELETER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp"
 #include "../utilities/pointer_utilities.hpp" // to_raw_pointer
 

--- a/include/bit/memory/adapters/polymorphic_allocator_deleter.hpp
+++ b/include/bit/memory/adapters/polymorphic_allocator_deleter.hpp
@@ -31,6 +31,10 @@
 #ifndef BIT_MEMORY_ADAPTERS_POLYMORPHIC_ALLOCATOR_DELETER_HPP
 #define BIT_MEMORY_ADAPTERS_POLYMORPHIC_ALLOCATOR_DELETER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp"
 #include "../utilities/pointer_utilities.hpp" // to_raw_pointer
 

--- a/include/bit/memory/adapters/polymorphic_allocator_deleter.hpp
+++ b/include/bit/memory/adapters/polymorphic_allocator_deleter.hpp
@@ -1,12 +1,33 @@
-/**
- * \file polymorphic_allocator_deleter.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines an allocator deleter that operates polymorphically
  *        with types, which comes at the cost of storing the size with each
  *        allocation
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ADAPTERS_POLYMORPHIC_ALLOCATOR_DELETER_HPP
 #define BIT_MEMORY_ADAPTERS_POLYMORPHIC_ALLOCATOR_DELETER_HPP
 

--- a/include/bit/memory/adapters/standard_allocator.hpp
+++ b/include/bit/memory/adapters/standard_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ADAPTERS_STANDARD_ALLOCATOR_HPP
 #define BIT_MEMORY_ADAPTERS_STANDARD_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp" // detail::ebo_storage
 
 #include "../concepts/AllocatorStorage.hpp" // is_allocator_storage

--- a/include/bit/memory/adapters/standard_allocator.hpp
+++ b/include/bit/memory/adapters/standard_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file standard_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines an adapter around bit::memory allocators that
  *        make them behave like the c++ standard's "Allocator" concept
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ADAPTERS_STANDARD_ALLOCATOR_HPP
 #define BIT_MEMORY_ADAPTERS_STANDARD_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocator_storage/referenced_allocator_storage.hpp
+++ b/include/bit/memory/allocator_storage/referenced_allocator_storage.hpp
@@ -1,11 +1,32 @@
-/**
- * \file allocator_reference_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a storage policy using allocators accessed by
  *        a reference
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATOR_STORAGE_REFERENCED_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_ALLOCATOR_STORAGE_REFERENCED_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/allocator_storage/referenced_allocator_storage.hpp
+++ b/include/bit/memory/allocator_storage/referenced_allocator_storage.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATOR_STORAGE_REFERENCED_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_ALLOCATOR_STORAGE_REFERENCED_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../concepts/Allocator.hpp"
 
 #include <memory> // std::addressof

--- a/include/bit/memory/allocator_storage/shared_allocator_storage.hpp
+++ b/include/bit/memory/allocator_storage/shared_allocator_storage.hpp
@@ -1,11 +1,32 @@
-/**
- * \file shared_allocator_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an AllocatorStorage type that has
  *        shared-ownership semantics of the underlying allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATOR_STORAGE_SHARED_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_ALLOCATOR_STORAGE_SHARED_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/allocator_storage/shared_allocator_storage.hpp
+++ b/include/bit/memory/allocator_storage/shared_allocator_storage.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATOR_STORAGE_SHARED_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_ALLOCATOR_STORAGE_SHARED_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../concepts/Allocator.hpp"
 
 #include <memory> // std::shared_ptr

--- a/include/bit/memory/allocator_storage/stateless_allocator_storage.hpp
+++ b/include/bit/memory/allocator_storage/stateless_allocator_storage.hpp
@@ -1,10 +1,31 @@
-/**
- * \file stateless_allocator_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a storage policy for stateless allocators
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATOR_STORAGE_STATELESS_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_ALLOCATOR_STORAGE_STATELESS_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/allocator_storage/stateless_allocator_storage.hpp
+++ b/include/bit/memory/allocator_storage/stateless_allocator_storage.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_ALLOCATOR_STORAGE_STATELESS_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_ALLOCATOR_STORAGE_STATELESS_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp"
 
 #include "../concepts/Stateless.hpp"

--- a/include/bit/memory/allocators/aligned_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file aligned_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of a RawAllocator used for
  *        aligned allocations
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/aligned_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_ALIGNED_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/allocators/aligned_offset_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_offset_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_ALIGNED_OFFSET_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_ALIGNED_OFFSET_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/allocators/aligned_offset_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_offset_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file aligned_offset_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of an allocator used for
  *        offset aligned allocations
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_ALIGNED_OFFSET_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_ALIGNED_OFFSET_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/allocator_reference.hpp
+++ b/include/bit/memory/allocators/allocator_reference.hpp
@@ -1,10 +1,31 @@
-/**
- * \file allocator_reference.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of a type-erased allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_ALLOCATOR_REFERENCE_HPP
 #define BIT_MEMORY_ALLOCATORS_ALLOCATOR_REFERENCE_HPP
 

--- a/include/bit/memory/allocators/allocator_reference.hpp
+++ b/include/bit/memory/allocators/allocator_reference.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_ALLOCATOR_REFERENCE_HPP
 #define BIT_MEMORY_ALLOCATORS_ALLOCATOR_REFERENCE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/owner.hpp"            // owner
 #include "../utilities/allocator_info.hpp"   // allocator_info
 #include "../utilities/macros.hpp"           // BIT_MEMORY_UNUSED

--- a/include/bit/memory/allocators/bump_down_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file bump_down_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of the ExtendedAllocator class,
  *        linear_allocator.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_DOWN_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_DOWN_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/bump_down_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_DOWN_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_DOWN_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/macros.hpp"            // BIT_MEMORY_UNLIKELY

--- a/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
@@ -31,6 +31,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_DOWN_LIFO_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_DOWN_LIFO_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/macros.hpp"            // BIT_MEMORY_UNLIKELY

--- a/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
@@ -1,12 +1,33 @@
-/**
- * \file bump_down_lifo_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a bump-down allocator that
  *        allows for stack-based LIFO deallocations alongside truncated
  *        deallocations
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_DOWN_LIFO_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_DOWN_LIFO_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/bump_up_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_UP_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_UP_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/macros.hpp"            // BIT_MEMORY_UNLIKELY

--- a/include/bit/memory/allocators/bump_up_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file bump_up_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of the ExtendedAllocator class,
  *        bump_up_allocator.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_UP_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_UP_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
@@ -31,6 +31,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_UP_LIFO_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_UP_LIFO_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/macros.hpp"            // BIT_MEMORY_UNLIKELY

--- a/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
@@ -1,12 +1,33 @@
-/**
- * \file bump_up_lifo_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a bump-up allocator that
  *        allows for stack-based LIFO deallocations alongside truncated
  *        deallocations
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_BUMP_UP_LIFO_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_BUMP_UP_LIFO_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/detail/named_allocator.hpp
+++ b/include/bit/memory/allocators/detail/named_allocator.hpp
@@ -1,12 +1,35 @@
-/**
- * \file named_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a composite operator that allows naming
  *        of the underlying allocator
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_DETAIL_NAMED_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_DETAIL_NAMED_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/detail/named_allocator.hpp
+++ b/include/bit/memory/allocators/detail/named_allocator.hpp
@@ -33,6 +33,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_DETAIL_NAMED_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_DETAIL_NAMED_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/allocator_info.hpp" // allocator_info
 
 #include <type_traits> // std::enable_if_t, std::is_constructible

--- a/include/bit/memory/allocators/fallback_allocator.hpp
+++ b/include/bit/memory/allocators/fallback_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_FALLBACK_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_FALLBACK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/ebo_storage.hpp" // detail::ebo_storage

--- a/include/bit/memory/allocators/fallback_allocator.hpp
+++ b/include/bit/memory/allocators/fallback_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file fallback_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines an allocator that falls-back on failure to other
  *        allocators
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_FALLBACK_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_FALLBACK_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/malloc_allocator.hpp
+++ b/include/bit/memory/allocators/malloc_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file malloc_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition for the RawAllocator,
  *        malloc_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_MALLOC_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_MALLOC_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/malloc_allocator.hpp
+++ b/include/bit/memory/allocators/malloc_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_MALLOC_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_MALLOC_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/allocators/new_allocator.hpp
+++ b/include/bit/memory/allocators/new_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file new_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition for the RawAllocator,
  *        new_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_NEW_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_NEW_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/new_allocator.hpp
+++ b/include/bit/memory/allocators/new_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_NEW_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_NEW_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/allocators/null_allocator.hpp
+++ b/include/bit/memory/allocators/null_allocator.hpp
@@ -1,10 +1,31 @@
-/**
- * \file null_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the null allocator policy, null_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_NULL_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_NULL_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/null_allocator.hpp
+++ b/include/bit/memory/allocators/null_allocator.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_NULL_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_NULL_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/allocators/policy_allocator.hpp
+++ b/include/bit/memory/allocators/policy_allocator.hpp
@@ -1,10 +1,31 @@
-/**
- * \file policy_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a policy-based allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_POLICY_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_POLICY_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/policy_allocator.hpp
+++ b/include/bit/memory/allocators/policy_allocator.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_POLICY_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_POLICY_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp" // detail::ebo_storage
 #include "../utilities/allocator_info.hpp" // allocator_info
 #include "../utilities/debugging.hpp"      // debug_tag_...

--- a/include/bit/memory/allocators/pool_allocator.hpp
+++ b/include/bit/memory/allocators/pool_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_POOL_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_POOL_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/freelist.hpp"          // freelist

--- a/include/bit/memory/allocators/pool_allocator.hpp
+++ b/include/bit/memory/allocators/pool_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file pool_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition for an allocator that creates
  *        fixed-sized allocations from a reused pool
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_POOL_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_POOL_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/stack_allocator.hpp
+++ b/include/bit/memory/allocators/stack_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file stack_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a stack allocator for
  *        temporary, automatic reclamation
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_ALLOCATORS_STACK_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_STACK_ALLOCATOR_HPP
 

--- a/include/bit/memory/allocators/stack_allocator.hpp
+++ b/include/bit/memory/allocators/stack_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_ALLOCATORS_STACK_ALLOCATOR_HPP
 #define BIT_MEMORY_ALLOCATORS_STACK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_allocator.hpp" // detail::named_allocator
 
 #include "../utilities/macros.hpp"            // BIT_MEMORY_UNLIKELY

--- a/include/bit/memory/block_allocator_storage/referenced_block_allocator_storage.hpp
+++ b/include/bit/memory/block_allocator_storage/referenced_block_allocator_storage.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_REFERENCED_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_REFERENCED_BLOCK_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../concepts/BlockAllocator.hpp"
 
 #include <memory> // std::addressof

--- a/include/bit/memory/block_allocator_storage/referenced_block_allocator_storage.hpp
+++ b/include/bit/memory/block_allocator_storage/referenced_block_allocator_storage.hpp
@@ -1,11 +1,32 @@
-/**
- * \file allocator_block_reference_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a storage policy using block allocators accessed
  *        by a reference
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_REFERENCED_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_REFERENCED_BLOCK_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/block_allocator_storage/shared_block_allocator_storage.hpp
+++ b/include/bit/memory/block_allocator_storage/shared_block_allocator_storage.hpp
@@ -1,11 +1,32 @@
-/**
- * \file shared_block_allocator_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a BlockAllocatorStorage type that has
  *        shared-ownership semantics of the underlying block allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_SHARED_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_SHARED_BLOCK_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/block_allocator_storage/shared_block_allocator_storage.hpp
+++ b/include/bit/memory/block_allocator_storage/shared_block_allocator_storage.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_SHARED_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_SHARED_BLOCK_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../concepts/BlockAllocator.hpp"
 
 #include <memory> // std::shared_ptr

--- a/include/bit/memory/block_allocator_storage/stateless_block_allocator_storage.hpp
+++ b/include/bit/memory/block_allocator_storage/stateless_block_allocator_storage.hpp
@@ -1,10 +1,31 @@
-/**
- * \file stateless_block_allocator_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a storage policy for stateless block allocators
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_STATELESS_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_STATELESS_BLOCK_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/block_allocator_storage/stateless_block_allocator_storage.hpp
+++ b/include/bit/memory/block_allocator_storage/stateless_block_allocator_storage.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_STATELESS_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATOR_STORAGE_STATELESS_BLOCK_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp"
 
 #include "../concepts/Stateless.hpp"

--- a/include/bit/memory/block_allocators/aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/aligned_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file aligned_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of a block allocator that
  *        allocates aligned memory
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_ALIGNED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_ALIGNED_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/aligned_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_ALIGNED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_ALIGNED_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/cached_block_allocator.hpp" // cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 

--- a/include/bit/memory/block_allocators/block_allocator_reference.hpp
+++ b/include/bit/memory/block_allocators/block_allocator_reference.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_BLOCK_ALLOCATOR_REFERENCE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_BLOCK_ALLOCATOR_REFERENCE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/owner.hpp"                  // owner
 #include "../utilities/allocator_info.hpp"         // allocator_info
 #include "../utilities/memory_block.hpp"           // memory_block

--- a/include/bit/memory/block_allocators/block_allocator_reference.hpp
+++ b/include/bit/memory/block_allocators/block_allocator_reference.hpp
@@ -1,10 +1,31 @@
-/**
- * \file block_allocator_reference.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a type-erased view of a BlockAllocator concept
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_BLOCK_ALLOCATOR_REFERENCE_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_BLOCK_ALLOCATOR_REFERENCE_HPP
 

--- a/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
@@ -1,12 +1,35 @@
-/**
- * \file cached_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an allocator adapter that caches previously
  *        allocated blocks
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_CACHED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_CACHED_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/detail/cached_block_allocator.hpp
@@ -33,6 +33,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_CACHED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_CACHED_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/owner.hpp"              // owner
 #include "../../utilities/memory_block.hpp"       // memory_block
 #include "../../utilities/memory_block_cache.hpp" // memory_block_cache

--- a/include/bit/memory/block_allocators/detail/named_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/detail/named_block_allocator.hpp
@@ -38,6 +38,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_NAMED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_NAMED_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 
 #include "../../utilities/allocator_info.hpp" // allocator_info
 

--- a/include/bit/memory/block_allocators/detail/named_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/detail/named_block_allocator.hpp
@@ -1,6 +1,5 @@
-/**
- * \file named_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a composite operator that allows naming
  *        of the underlying block allocator
  *
@@ -11,7 +10,31 @@
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_NAMED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_NAMED_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_ALIGNED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_ALIGNED_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/cached_block_allocator.hpp" // cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 

--- a/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file growing_aligned_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an aligned block allocator that grows in size
  *        with each subsequent block allocation
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_ALIGNED_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_ALIGNED_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file growing_malloc_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a block allocator that increasingly grows the
  *        block size until reaching a final threshhold
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_MALLOC_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_MALLOC_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_MALLOC_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_MALLOC_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 

--- a/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file growing_new_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a block allocator that increasingly grows the
  *        block size until reaching a final threshhold
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_NEW_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_NEW_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_NEW_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_NEW_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 

--- a/include/bit/memory/block_allocators/growing_virtual_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_virtual_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file growing_virtual_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of a growing block allocator
  *        that allocates virtual memory
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_VIRTUAL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_VIRTUAL_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/growing_virtual_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_virtual_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_VIRTUAL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_GROWING_VIRTUAL_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
 #include "../utilities/allocator_info.hpp"     // allocator_info

--- a/include/bit/memory/block_allocators/malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/malloc_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file malloc_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an implementation of a non-aligned, malloc
  *        block allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_MALLOC_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_MALLOC_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/malloc_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_MALLOC_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_MALLOC_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 

--- a/include/bit/memory/block_allocators/new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/new_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file new_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an API for allocating memory blocks that use
  *        ::operator new as the underlying allocation scheme.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_NEW_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_NEW_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/new_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_NEW_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_NEW_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/cached_block_allocator.hpp" // detail::cached_block_allocator
 #include "detail/named_block_allocator.hpp"  // detail::named_block_allocator
 

--- a/include/bit/memory/block_allocators/null_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/null_block_allocator.hpp
@@ -1,10 +1,31 @@
-/**
- * \file null_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the null block allocator, null_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_NULL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_NULL_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/null_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/null_block_allocator.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_NULL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_NULL_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
 #include "../utilities/allocator_info.hpp"    // allocator_info

--- a/include/bit/memory/block_allocators/policy_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/policy_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file policy_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a block allocator that uses policy-based design
  *        to componentize entries
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_POLICY_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_POLICY_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/policy_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/policy_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_POLICY_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_POLICY_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/ebo_storage.hpp"      // detail::ebo_storage
 #include "../utilities/allocator_info.hpp"         // allocator_info
 #include "../utilities/memory_block.hpp"           // memory_block

--- a/include/bit/memory/block_allocators/stack_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/stack_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_STACK_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_STACK_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
 #include "../utilities/allocator_info.hpp"     // allocator_info

--- a/include/bit/memory/block_allocators/stack_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/stack_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file stack_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a block allocator that uses
  *        the stack for temporary, automatic cleanup
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_STACK_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_STACK_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/static_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/static_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file static_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition for an allocator that can only
  *        allocate a single static block
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_STATIC_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_STATIC_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/static_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/static_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_STATIC_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_STATIC_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
 #include "../utilities/owner.hpp"              // owner

--- a/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_THREAD_LOCAL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_THREAD_LOCAL_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
 #include "../utilities/allocator_info.hpp"     // allocator_info

--- a/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/thread_local_block_allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file thread_local_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines a thread-local variant of the static block
  *        allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_THREAD_LOCAL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_THREAD_LOCAL_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/virtual_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/virtual_block_allocator.hpp
@@ -1,10 +1,31 @@
-/**
- * \file virtual_block_allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an implementation of a virtual-block allocator.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_VIRTUAL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_VIRTUAL_BLOCK_ALLOCATOR_HPP
 

--- a/include/bit/memory/block_allocators/virtual_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/virtual_block_allocator.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_BLOCK_ALLOCATORS_VIRTUAL_BLOCK_ALLOCATOR_HPP
 #define BIT_MEMORY_BLOCK_ALLOCATORS_VIRTUAL_BLOCK_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/named_block_allocator.hpp" // detail::named_block_allocator
 
 #include "../utilities/allocator_info.hpp"     // allocator_info

--- a/include/bit/memory/concepts/Allocator.hpp
+++ b/include/bit/memory/concepts/Allocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file Allocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concepts and type-traits relating to the
  *        Allocator concept
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_ALLOCATOR_HPP
 #define BIT_MEMORY_CONCEPTS_ALLOCATOR_HPP
 

--- a/include/bit/memory/concepts/Allocator.hpp
+++ b/include/bit/memory/concepts/Allocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_ALLOCATOR_HPP
 #define BIT_MEMORY_CONCEPTS_ALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/identity.hpp"            // detail::identity
 #include "detail/void_t.hpp"              // detail::void_t
 #include "detail/allocator_utilities.hpp" // allocator_size_type

--- a/include/bit/memory/concepts/AllocatorStorage.hpp
+++ b/include/bit/memory/concepts/AllocatorStorage.hpp
@@ -1,11 +1,32 @@
-/**
- * \file AllocatorStorage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concept of an 'AllocatorStorage', which is
  *        used to contain allocator types within composites.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_CONCEPTS_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/concepts/AllocatorStorage.hpp
+++ b/include/bit/memory/concepts/AllocatorStorage.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_CONCEPTS_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include "Allocator.hpp" // is_allocator

--- a/include/bit/memory/concepts/BasicLockable.hpp
+++ b/include/bit/memory/concepts/BasicLockable.hpp
@@ -1,10 +1,31 @@
-/**
- * \file BasicLockable.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concept for a BasicLockable
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_BASICLOCKABLE_HPP
 #define BIT_MEMORY_CONCEPTS_BASICLOCKABLE_HPP
 

--- a/include/bit/memory/concepts/BasicLockable.hpp
+++ b/include/bit/memory/concepts/BasicLockable.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_BASICLOCKABLE_HPP
 #define BIT_MEMORY_CONCEPTS_BASICLOCKABLE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include <type_traits> // std::declval, std::true_type

--- a/include/bit/memory/concepts/BlockAllocator.hpp
+++ b/include/bit/memory/concepts/BlockAllocator.hpp
@@ -1,11 +1,32 @@
-/**
- * \file BlockAllocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definitions for the 'BlockAllocator'
  *        concept and related type-traits
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ ****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_BLOCKALLOCATOR_HPP
 #define BIT_MEMORY_CONCEPTS_BLOCKALLOCATOR_HPP
 

--- a/include/bit/memory/concepts/BlockAllocator.hpp
+++ b/include/bit/memory/concepts/BlockAllocator.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_BLOCKALLOCATOR_HPP
 #define BIT_MEMORY_CONCEPTS_BLOCKALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/identity.hpp" // detail::identity
 #include "detail/void_t.hpp"   // detail::void_t
 

--- a/include/bit/memory/concepts/BlockAllocatorStorage.hpp
+++ b/include/bit/memory/concepts/BlockAllocatorStorage.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_CONCEPTS_BLOCK_ALLOCATOR_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include "BlockAllocator.hpp" // is_block_allocator

--- a/include/bit/memory/concepts/BlockAllocatorStorage.hpp
+++ b/include/bit/memory/concepts/BlockAllocatorStorage.hpp
@@ -1,11 +1,32 @@
-/**
- * \file BlockAllocatorStorage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concept of an 'BlockAllocatorStorage', which
  *        is used to contain block allocator types within composites.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_BLOCK_ALLOCATOR_STORAGE_HPP
 #define BIT_MEMORY_CONCEPTS_BLOCK_ALLOCATOR_STORAGE_HPP
 

--- a/include/bit/memory/concepts/BoundsChecker.hpp
+++ b/include/bit/memory/concepts/BoundsChecker.hpp
@@ -1,10 +1,31 @@
-/**
- * \file BoundsChecker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concept for a BoundsChecker
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_BOUNDSCHECKER_HPP
 #define BIT_MEMORY_CONCEPTS_BOUNDSCHECKER_HPP
 

--- a/include/bit/memory/concepts/BoundsChecker.hpp
+++ b/include/bit/memory/concepts/BoundsChecker.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_BOUNDSCHECKER_HPP
 #define BIT_MEMORY_CONCEPTS_BOUNDSCHECKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/concepts/Deleter.hpp
+++ b/include/bit/memory/concepts/Deleter.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_DELETER_HPP
 #define BIT_MEMORY_CONCEPTS_DELETER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include <type_traits> // std::integral_constants

--- a/include/bit/memory/concepts/Deleter.hpp
+++ b/include/bit/memory/concepts/Deleter.hpp
@@ -1,10 +1,31 @@
-/**
- * \file Deleter.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief TODO: Add description
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_DELETER_HPP
 #define BIT_MEMORY_CONCEPTS_DELETER_HPP
 

--- a/include/bit/memory/concepts/ExtendedAllocator.hpp
+++ b/include/bit/memory/concepts/ExtendedAllocator.hpp
@@ -1,10 +1,31 @@
-/**
- * \file ExtendedAllocator.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concepts for the ExtendedAllocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_EXTENDEDALLOCATOR_HPP
 #define BIT_MEMORY_CONCEPTS_EXTENDEDALLOCATOR_HPP
 

--- a/include/bit/memory/concepts/ExtendedAllocator.hpp
+++ b/include/bit/memory/concepts/ExtendedAllocator.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_EXTENDEDALLOCATOR_HPP
 #define BIT_MEMORY_CONCEPTS_EXTENDEDALLOCATOR_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/allocator_utilities.hpp" // allocator_pointer_t
 #include "detail/identity.hpp"            // detail::identity
 #include "detail/void_t.hpp"              // detail::void_t

--- a/include/bit/memory/concepts/MemoryTagger.hpp
+++ b/include/bit/memory/concepts/MemoryTagger.hpp
@@ -1,10 +1,31 @@
-/**
- * \file MemoryTagger.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concept for a MemoryTagger
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_MEMORYTAGGER_HPP
 #define BIT_MEMORY_CONCEPTS_MEMORYTAGGER_HPP
 

--- a/include/bit/memory/concepts/MemoryTagger.hpp
+++ b/include/bit/memory/concepts/MemoryTagger.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_MEMORYTAGGER_HPP
 #define BIT_MEMORY_CONCEPTS_MEMORYTAGGER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include <cstddef>     // std::size_t

--- a/include/bit/memory/concepts/MemoryTracker.hpp
+++ b/include/bit/memory/concepts/MemoryTracker.hpp
@@ -1,10 +1,31 @@
-/**
- * \file MemoryTracker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the concept for a MemoryTracker
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_MEMORYTRACKER_HPP
 #define BIT_MEMORY_CONCEPTS_MEMORYTRACKER_HPP
 

--- a/include/bit/memory/concepts/MemoryTracker.hpp
+++ b/include/bit/memory/concepts/MemoryTracker.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_MEMORYTRACKER_HPP
 #define BIT_MEMORY_CONCEPTS_MEMORYTRACKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include "../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/concepts/Stateless.hpp
+++ b/include/bit/memory/concepts/Stateless.hpp
@@ -1,11 +1,32 @@
-/**
- * \file Stateless.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definitions for the 'Stateless' concepts and
  *        related type-traits
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_STATELESS_HPP
 #define BIT_MEMORY_CONCEPTS_STATELESS_HPP
 

--- a/include/bit/memory/concepts/Stateless.hpp
+++ b/include/bit/memory/concepts/Stateless.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_STATELESS_HPP
 #define BIT_MEMORY_CONCEPTS_STATELESS_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/void_t.hpp" // detail::void_t
 
 #include <type_traits> // std::integral_constants

--- a/include/bit/memory/concepts/detail/allocator_utilities.hpp
+++ b/include/bit/memory/concepts/detail/allocator_utilities.hpp
@@ -1,12 +1,35 @@
-/**
- * \file allocator_utilities.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This internal header defines various utilities for extracting
  *        allocator-defined types (used for pretty-pointers)
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_CONCEPTS_DETAIL_ALLOCATOR_UTILITIES_HPP
 #define BIT_MEMORY_CONCEPTS_DETAIL_ALLOCATOR_UTILITIES_HPP
 

--- a/include/bit/memory/concepts/detail/allocator_utilities.hpp
+++ b/include/bit/memory/concepts/detail/allocator_utilities.hpp
@@ -33,6 +33,10 @@
 #ifndef BIT_MEMORY_CONCEPTS_DETAIL_ALLOCATOR_UTILITIES_HPP
 #define BIT_MEMORY_CONCEPTS_DETAIL_ALLOCATOR_UTILITIES_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "identity.hpp" // detail::identity
 #include "void_t.hpp"   // detail::void_t
 

--- a/include/bit/memory/concepts/detail/identity.hpp
+++ b/include/bit/memory/concepts/detail/identity.hpp
@@ -1,12 +1,35 @@
-/**
- * \file identity.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This internal header contains the definition of two useful
  *        template-meta-programming utilities
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_DETAIL_IDENTITY_HPP
 #define BIT_MEMORY_DETAIL_IDENTITY_HPP
 

--- a/include/bit/memory/concepts/detail/identity.hpp
+++ b/include/bit/memory/concepts/detail/identity.hpp
@@ -33,6 +33,10 @@
 #ifndef BIT_MEMORY_DETAIL_IDENTITY_HPP
 #define BIT_MEMORY_DETAIL_IDENTITY_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 namespace bit {
   namespace memory {
     namespace detail {

--- a/include/bit/memory/concepts/detail/void_t.hpp
+++ b/include/bit/memory/concepts/detail/void_t.hpp
@@ -33,6 +33,10 @@
 #ifndef BIT_MEMORY_DETAIL_VOID_T_HPP
 #define BIT_MEMORY_DETAIL_VOID_T_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 namespace bit {
   namespace memory {
     namespace detail {

--- a/include/bit/memory/concepts/detail/void_t.hpp
+++ b/include/bit/memory/concepts/detail/void_t.hpp
@@ -1,12 +1,35 @@
-/**
- * \file void_t.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition for \c void_t to be used for
  *        various template type-traits
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_DETAIL_VOID_T_HPP
 #define BIT_MEMORY_DETAIL_VOID_T_HPP
 

--- a/include/bit/memory/policies/bounds_checkers/debug_bounds_checker.hpp
+++ b/include/bit/memory/policies/bounds_checkers/debug_bounds_checker.hpp
@@ -1,10 +1,31 @@
-/**
- * \file debug_bounds_checker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of a debug bounds checker
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_DEBUG_BOUNDS_CHECKER_HPP
 #define BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_DEBUG_BOUNDS_CHECKER_HPP
 

--- a/include/bit/memory/policies/bounds_checkers/debug_bounds_checker.hpp
+++ b/include/bit/memory/policies/bounds_checkers/debug_bounds_checker.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_DEBUG_BOUNDS_CHECKER_HPP
 #define BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_DEBUG_BOUNDS_CHECKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/allocator_info.hpp" // allocator_info
 #include "../../utilities/debugging.hpp"      // debug_tag_start_bytes, etc
 #include "../../utilities/errors.hpp"         // get_buffer_overflow_handler

--- a/include/bit/memory/policies/bounds_checkers/null_bounds_checker.hpp
+++ b/include/bit/memory/policies/bounds_checkers/null_bounds_checker.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_NULL_BOUNDS_CHECKER_HPP
 #define BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_NULL_BOUNDS_CHECKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/allocator_info.hpp" // allocator_info
 
 #include "../../concepts/BoundsChecker.hpp" // is_bounds_checker

--- a/include/bit/memory/policies/bounds_checkers/null_bounds_checker.hpp
+++ b/include/bit/memory/policies/bounds_checkers/null_bounds_checker.hpp
@@ -1,11 +1,32 @@
-/**
- * \file null_bounds_checker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a null (no-operation)
  *        BoundsChecker
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_NULL_BOUNDS_CHECKER_HPP
 #define BIT_MEMORY_POLICIES_BOUNDS_CHECKERS_NULL_BOUNDS_CHECKER_HPP
 

--- a/include/bit/memory/policies/lockables/null_lock.hpp
+++ b/include/bit/memory/policies/lockables/null_lock.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_POLICIES_LOCKABLES_NULL_LOCK_HPP
 #define BIT_MEMORY_POLICIES_LOCKABLES_NULL_LOCK_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../concepts/BasicLockable.hpp"
 
 namespace bit {

--- a/include/bit/memory/policies/lockables/null_lock.hpp
+++ b/include/bit/memory/policies/lockables/null_lock.hpp
@@ -1,10 +1,31 @@
-/**
- * \file null_lock.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition for a null (no-op) BasicLockable
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_LOCKABLES_NULL_LOCK_HPP
 #define BIT_MEMORY_POLICIES_LOCKABLES_NULL_LOCK_HPP
 

--- a/include/bit/memory/policies/taggers/allocator_tagger.hpp
+++ b/include/bit/memory/policies/taggers/allocator_tagger.hpp
@@ -1,11 +1,32 @@
-/**
- * \file allocator_tagger.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a debug tagger that tags
  *        allocations with specific byte-patterns.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TAGGERS_DEBUG_MEMORY_TAGGER_HPP
 #define BIT_MEMORY_POLICIES_TAGGERS_DEBUG_MEMORY_TAGGER_HPP
 

--- a/include/bit/memory/policies/taggers/allocator_tagger.hpp
+++ b/include/bit/memory/policies/taggers/allocator_tagger.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_POLICIES_TAGGERS_DEBUG_MEMORY_TAGGER_HPP
 #define BIT_MEMORY_POLICIES_TAGGERS_DEBUG_MEMORY_TAGGER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/debugging.hpp" // debug_tag_allocated_bytes
 
 #include "../../concepts/MemoryTagger.hpp" // is_memory_tagger

--- a/include/bit/memory/policies/taggers/block_allocator_tagger.hpp
+++ b/include/bit/memory/policies/taggers/block_allocator_tagger.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_POLICIES_TAGGERS_BLOCK_ALLOCATOR_TAGGER_HPP
 #define BIT_MEMORY_POLICIES_TAGGERS_BLOCK_ALLOCATOR_TAGGER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/debugging.hpp" // debug_tag_allocated_bytes
 
 #include "../../concepts/MemoryTagger.hpp" // is_memory_tagger

--- a/include/bit/memory/policies/taggers/block_allocator_tagger.hpp
+++ b/include/bit/memory/policies/taggers/block_allocator_tagger.hpp
@@ -1,11 +1,32 @@
-/**
- * \file block_allocator_tagger.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a debug tagger that tags
  *        allocations with specific byte-patterns.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TAGGERS_BLOCK_ALLOCATOR_TAGGER_HPP
 #define BIT_MEMORY_POLICIES_TAGGERS_BLOCK_ALLOCATOR_TAGGER_HPP
 

--- a/include/bit/memory/policies/taggers/null_tagger.hpp
+++ b/include/bit/memory/policies/taggers/null_tagger.hpp
@@ -1,10 +1,31 @@
-/**
- * \file null_tagger.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a null (no-op) MemoryTagger
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TAGGERS_NULL_TAGGER_HPP
 #define BIT_MEMORY_POLICIES_TAGGERS_NULL_TAGGER_HPP
 

--- a/include/bit/memory/policies/taggers/null_tagger.hpp
+++ b/include/bit/memory/policies/taggers/null_tagger.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_POLICIES_TAGGERS_NULL_TAGGER_HPP
 #define BIT_MEMORY_POLICIES_TAGGERS_NULL_TAGGER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../concepts/MemoryTagger.hpp" // is_memory_tagger
 
 #include <cstddef> // std::size_t

--- a/include/bit/memory/policies/trackers/detail/stat_recording_tracker.hpp
+++ b/include/bit/memory/policies/trackers/detail/stat_recording_tracker.hpp
@@ -32,6 +32,10 @@
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_DETAIL_STAT_RECORDING_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_DETAIL_STAT_RECORDING_TRACKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../../utilities/allocator_info.hpp" // allocator_info
 
 #include <cstddef> // std::size_t

--- a/include/bit/memory/policies/trackers/detail/stat_recording_tracker.hpp
+++ b/include/bit/memory/policies/trackers/detail/stat_recording_tracker.hpp
@@ -1,12 +1,34 @@
-/**
- * \file stat_recording_tracker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the implementation of a statistic tracking
  *        MemoryTracker
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
  */
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_DETAIL_STAT_RECORDING_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_DETAIL_STAT_RECORDING_TRACKER_HPP
 

--- a/include/bit/memory/policies/trackers/detailed_leak_tracker.hpp
+++ b/include/bit/memory/policies/trackers/detailed_leak_tracker.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_DETAILED_LEAK_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_DETAILED_LEAK_TRACKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/stat_recording_tracker.hpp" // detail::stat_recording_tracker
 
 #include "../../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/policies/trackers/detailed_leak_tracker.hpp
+++ b/include/bit/memory/policies/trackers/detailed_leak_tracker.hpp
@@ -1,11 +1,32 @@
-/**
- * \file detailed_leak_tracker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a detailed memory tracker used to watch every
  *        individual allocation
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_DETAILED_LEAK_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_DETAILED_LEAK_TRACKER_HPP
 

--- a/include/bit/memory/policies/trackers/leak_tracker.hpp
+++ b/include/bit/memory/policies/trackers/leak_tracker.hpp
@@ -1,10 +1,31 @@
-/**
- * \file leak_tracker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a basic leak tracker
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_LEAK_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_LEAK_TRACKER_HPP
 

--- a/include/bit/memory/policies/trackers/leak_tracker.hpp
+++ b/include/bit/memory/policies/trackers/leak_tracker.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_LEAK_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_LEAK_TRACKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/stat_recording_tracker.hpp" // detail::stat_recording_tracker
 
 #include "../../utilities/allocator_info.hpp" // allocator_info

--- a/include/bit/memory/policies/trackers/null_tracker.hpp
+++ b/include/bit/memory/policies/trackers/null_tracker.hpp
@@ -1,10 +1,31 @@
-/**
- * \file null_tracker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a null (no-op) MemoryTracker
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_NULL_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_NULL_TRACKER_HPP
 

--- a/include/bit/memory/policies/trackers/null_tracker.hpp
+++ b/include/bit/memory/policies/trackers/null_tracker.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_NULL_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_NULL_TRACKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "detail/stat_recording_tracker.hpp" // detail::stat_recording_tracker
 
 #include "../../utilities/allocator_info.hpp"   // allocator_info

--- a/include/bit/memory/policies/trackers/stdout_tracker.hpp
+++ b/include/bit/memory/policies/trackers/stdout_tracker.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_TRACKERS_STDOUT_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_TRACKERS_STDOUT_TRACKER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../../utilities/allocator_info.hpp" // allocator_info
 #include "../../utilities/macros.hpp"         // BIT_MEMORY_UNUSED
 

--- a/include/bit/memory/policies/trackers/stdout_tracker.hpp
+++ b/include/bit/memory/policies/trackers/stdout_tracker.hpp
@@ -1,10 +1,31 @@
-/**
- * \file stdout_tracker.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief TODO: Add description
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_POLICIES_TRACKERS_TRACKERS_STDOUT_TRACKER_HPP
 #define BIT_MEMORY_POLICIES_TRACKERS_TRACKERS_STDOUT_TRACKER_HPP
 

--- a/include/bit/memory/regions/aligned_heap_memory.hpp
+++ b/include/bit/memory/regions/aligned_heap_memory.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_REGIONS_ALIGNED_HEAP_MEMORY_HPP
 #define BIT_MEMORY_REGIONS_ALIGNED_HEAP_MEMORY_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <new> // std::nothrow_t
 
 namespace bit {

--- a/include/bit/memory/regions/aligned_heap_memory.hpp
+++ b/include/bit/memory/regions/aligned_heap_memory.hpp
@@ -1,11 +1,32 @@
-/**
- * \file aligned_memory.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains functions and global new operators for
  *        allocating blocks of aligned memory
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_REGIONS_ALIGNED_HEAP_MEMORY_HPP
 #define BIT_MEMORY_REGIONS_ALIGNED_HEAP_MEMORY_HPP
 

--- a/include/bit/memory/regions/virtual_memory.hpp
+++ b/include/bit/memory/regions/virtual_memory.hpp
@@ -1,10 +1,31 @@
-/**
- * \file virtual_memory.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header provides an implementation of virtual memory access
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_REGIONS_VIRTUAL_MEMORY_HPP
 #define BIT_MEMORY_REGIONS_VIRTUAL_MEMORY_HPP
 

--- a/include/bit/memory/regions/virtual_memory.hpp
+++ b/include/bit/memory/regions/virtual_memory.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_REGIONS_VIRTUAL_MEMORY_HPP
 #define BIT_MEMORY_REGIONS_VIRTUAL_MEMORY_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/memory_block.hpp"       // memory_block
 #include "../utilities/memory_block_cache.hpp" // memory_block_cache
 

--- a/include/bit/memory/traits/allocator_traits.hpp
+++ b/include/bit/memory/traits/allocator_traits.hpp
@@ -1,11 +1,32 @@
-/**
- * \file allocator_traits.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the trait type \c allocator_traits that
  *        determines or infers default values for the Allocator concept
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_TRAITS_ALLOCATOR_TRAITS_HPP
 #define BIT_MEMORY_TRAITS_ALLOCATOR_TRAITS_HPP
 

--- a/include/bit/memory/traits/allocator_traits.hpp
+++ b/include/bit/memory/traits/allocator_traits.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_TRAITS_ALLOCATOR_TRAITS_HPP
 #define BIT_MEMORY_TRAITS_ALLOCATOR_TRAITS_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/allocator_info.hpp"        // allocator_info
 #include "../utilities/errors.hpp"                // get_out_of_memory_handler
 #include "../utilities/macros.hpp"                // BIT_MEMORY_UNUSED

--- a/include/bit/memory/traits/block_allocator_traits.hpp
+++ b/include/bit/memory/traits/block_allocator_traits.hpp
@@ -1,14 +1,35 @@
-/**
- * \file block_allocator_traits.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines traits for block_allocators
  *
  * Currently, this library does not contain any optional features
  * that a block_allocator may define; but is defined and used for
  * ensuring forward-compatibility as things change
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_TRAITS_BLOCK_ALLOCATOR_TRAITS_HPP
 #define BIT_MEMORY_TRAITS_BLOCK_ALLOCATOR_TRAITS_HPP
 

--- a/include/bit/memory/traits/block_allocator_traits.hpp
+++ b/include/bit/memory/traits/block_allocator_traits.hpp
@@ -33,6 +33,10 @@
 #ifndef BIT_MEMORY_TRAITS_BLOCK_ALLOCATOR_TRAITS_HPP
 #define BIT_MEMORY_TRAITS_BLOCK_ALLOCATOR_TRAITS_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "../utilities/allocator_info.hpp" // allocator_info
 #include "../utilities/macros.hpp"         // BIT_MEMORY_UNUSED
 #include "../utilities/memory_block.hpp"   // memory_block

--- a/include/bit/memory/utilities/allocator_info.hpp
+++ b/include/bit/memory/utilities/allocator_info.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_UTILITIES_ALLOCATOR_INFO_HPP
 #define BIT_MEMORY_UTILITIES_ALLOCATOR_INFO_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 namespace bit {
   namespace memory {
 

--- a/include/bit/memory/utilities/allocator_info.hpp
+++ b/include/bit/memory/utilities/allocator_info.hpp
@@ -1,11 +1,32 @@
-/**
- * \file allocator_info.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the generic identifier used for identifying
  *        unique named allocators
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_ALLOCATOR_INFO_HPP
 #define BIT_MEMORY_UTILITIES_ALLOCATOR_INFO_HPP
 

--- a/include/bit/memory/utilities/debugging.hpp
+++ b/include/bit/memory/utilities/debugging.hpp
@@ -1,10 +1,31 @@
-/**
- * \file debugging.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains definitions for various debugging utilities
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_DEBUGGING_HPP
 #define BIT_MEMORY_UTILITIES_DEBUGGING_HPP
 

--- a/include/bit/memory/utilities/debugging.hpp
+++ b/include/bit/memory/utilities/debugging.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_UTILITIES_DEBUGGING_HPP
 #define BIT_MEMORY_UTILITIES_DEBUGGING_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "memory_block.hpp" // memory_block
 
 #include <cstddef>   // std::size_t

--- a/include/bit/memory/utilities/dynamic_size_type.hpp
+++ b/include/bit/memory/utilities/dynamic_size_type.hpp
@@ -32,6 +32,10 @@
 #ifndef BIT_MEMORY_UTILITIES_DYNAMIC_SIZE_TYPE_HPP
 #define BIT_MEMORY_UTILITIES_DYNAMIC_SIZE_TYPE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <cstddef>     // std::size_t
 #include <type_traits> // std::true_type, std::false_type
 

--- a/include/bit/memory/utilities/dynamic_size_type.hpp
+++ b/include/bit/memory/utilities/dynamic_size_type.hpp
@@ -1,12 +1,34 @@
-/**
- * \file dynamic_size_type.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This internal header contains an EBO-optimized type for storing
  *        possibly compile-time size values.
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
  */
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_DYNAMIC_SIZE_TYPE_HPP
 #define BIT_MEMORY_UTILITIES_DYNAMIC_SIZE_TYPE_HPP
 

--- a/include/bit/memory/utilities/ebo_storage.hpp
+++ b/include/bit/memory/utilities/ebo_storage.hpp
@@ -32,6 +32,10 @@
 #ifndef BIT_MEMORY_UTILITIES_DETAIL_EBO_STORAGE_HPP
 #define BIT_MEMORY_UTILITIES_DETAIL_EBO_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <cstddef>     // std::size_t
 #include <tuple>       // std::tuple_size
 #include <type_traits> // std::integral_constant, std::enable_if, etc...

--- a/include/bit/memory/utilities/ebo_storage.hpp
+++ b/include/bit/memory/utilities/ebo_storage.hpp
@@ -1,12 +1,34 @@
-/**
- * \file ebo_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains an internal-only implementation of an EBO
  *        helper to reduce class-sizes.
  *
  * \note This is an internal header file, included by other library headers.
  *       Do not attempt to use it directly.
  */
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_DETAIL_EBO_STORAGE_HPP
 #define BIT_MEMORY_UTILITIES_DETAIL_EBO_STORAGE_HPP
 

--- a/include/bit/memory/utilities/endian.hpp
+++ b/include/bit/memory/utilities/endian.hpp
@@ -1,11 +1,32 @@
-/**
- * \file endian.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains various utilities for converting between
  *        different endiannesses
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_ENDIAN_HPP
 #define BIT_MEMORY_UTILITIES_ENDIAN_HPP
 

--- a/include/bit/memory/utilities/endian.hpp
+++ b/include/bit/memory/utilities/endian.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_UTILITIES_ENDIAN_HPP
 #define BIT_MEMORY_UTILITIES_ENDIAN_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <algorithm>   // std::reverse
 #include <cstdint>     // std::int8_t, std::uint8_t, etc
 #include <type_traits> // std::is_copy_constructible, std::enable_if_t, etc

--- a/include/bit/memory/utilities/errors.hpp
+++ b/include/bit/memory/utilities/errors.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_UTILITIES_ERRORS_HPP
 #define BIT_MEMORY_UTILITIES_ERRORS_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "allocator_info.hpp"
 
 #include <cstddef> // std::size_t, std::ptrdiff_t

--- a/include/bit/memory/utilities/errors.hpp
+++ b/include/bit/memory/utilities/errors.hpp
@@ -1,11 +1,32 @@
-/**
- * \file errors.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a collection of various error handlers to be
  *        used by allocators
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_ERRORS_HPP
 #define BIT_MEMORY_UTILITIES_ERRORS_HPP
 

--- a/include/bit/memory/utilities/freelist.hpp
+++ b/include/bit/memory/utilities/freelist.hpp
@@ -1,10 +1,31 @@
-/**
- * \file freelist.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains the definition of a simple freelist utility
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_FREELIST_HPP
 #define BIT_MEMORY_UTILITIES_FREELIST_HPP
 

--- a/include/bit/memory/utilities/freelist.hpp
+++ b/include/bit/memory/utilities/freelist.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_UTILITIES_FREELIST_HPP
 #define BIT_MEMORY_UTILITIES_FREELIST_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "pointer_utilities.hpp"     // align_of
 #include "uninitialized_storage.hpp" // uninitialized_construct_at
 

--- a/include/bit/memory/utilities/macros.hpp
+++ b/include/bit/memory/utilities/macros.hpp
@@ -1,10 +1,31 @@
-/**
- * \file macros.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains useful macros for the rest of the library
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_MACROS_HPP
 #define BIT_MEMORY_UTILITIES_MACROS_HPP
 

--- a/include/bit/memory/utilities/macros.hpp
+++ b/include/bit/memory/utilities/macros.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_UTILITIES_MACROS_HPP
 #define BIT_MEMORY_UTILITIES_MACROS_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #ifdef BIT_MEMORY_LIKELY
 #error BIT_MEMORY_LIKELY cannot be defined outside of macros.hpp
 #endif

--- a/include/bit/memory/utilities/memory_block.hpp
+++ b/include/bit/memory/utilities/memory_block.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_UTILITIES_MEMORY_BLOCK_HPP
 #define BIT_MEMORY_UTILITIES_MEMORY_BLOCK_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <cstdlib> // std::size_t
 #include <utility> // std::swap
 

--- a/include/bit/memory/utilities/memory_block.hpp
+++ b/include/bit/memory/utilities/memory_block.hpp
@@ -1,11 +1,32 @@
-/**
- * \file memory_block.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains implementation for both the memory_block and
  *        the memory_block_cache.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_MEMORY_BLOCK_HPP
 #define BIT_MEMORY_UTILITIES_MEMORY_BLOCK_HPP
 

--- a/include/bit/memory/utilities/memory_block_cache.hpp
+++ b/include/bit/memory/utilities/memory_block_cache.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_UTILITIES_MEMORY_BLOCK_CACHE_HPP
 #define BIT_MEMORY_UTILITIES_MEMORY_BLOCK_CACHE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include "owner.hpp"                 // owner
 #include "memory_block.hpp"          // memory_block
 #include "pointer_utilities.hpp"     // align_of

--- a/include/bit/memory/utilities/memory_block_cache.hpp
+++ b/include/bit/memory/utilities/memory_block_cache.hpp
@@ -1,11 +1,32 @@
-/**
- * \file memory_block_cache.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains definitions for an intrinsically linked list
  *        of available memory_blocks
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_MEMORY_BLOCK_CACHE_HPP
 #define BIT_MEMORY_UTILITIES_MEMORY_BLOCK_CACHE_HPP
 

--- a/include/bit/memory/utilities/not_null.hpp
+++ b/include/bit/memory/utilities/not_null.hpp
@@ -1,10 +1,31 @@
-/**
- * \file not_null.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains a utility for guaranteeing non-null pointers
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_NOT_NULL_HPP
 #define BIT_MEMORY_UTILITIES_NOT_NULL_HPP
 

--- a/include/bit/memory/utilities/not_null.hpp
+++ b/include/bit/memory/utilities/not_null.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_UTILITIES_NOT_NULL_HPP
 #define BIT_MEMORY_UTILITIES_NOT_NULL_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <cassert>     // assert
 #include <cstddef>     // std::nullptr_t
 #include <type_traits> // std::is_assignable

--- a/include/bit/memory/utilities/owner.hpp
+++ b/include/bit/memory/utilities/owner.hpp
@@ -32,6 +32,10 @@
 #ifndef BIT_MEMORY_UTILITIES_OWNER_HPP
 #define BIT_MEMORY_UTILITIES_OWNER_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 namespace bit {
   namespace memory {
 

--- a/include/bit/memory/utilities/owner.hpp
+++ b/include/bit/memory/utilities/owner.hpp
@@ -1,13 +1,34 @@
-/**
- * \file owner.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines the alias 'owner' for indicating memory ownership
  *
  * \remark This is quite possibly the smallest header in this library; but also
  *         a very useful utility for self-documenting code
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_OWNER_HPP
 #define BIT_MEMORY_UTILITIES_OWNER_HPP
 

--- a/include/bit/memory/utilities/pointer_utilities.hpp
+++ b/include/bit/memory/utilities/pointer_utilities.hpp
@@ -30,6 +30,10 @@
 #ifndef BIT_MEMORY_UTILITIES_POINTER_UTILITIES_HPP
 #define BIT_MEMORY_UTILITIES_POINTER_UTILITIES_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <cstdint> // std::uintptr_t
 #include <cstddef> // std::size_t, std::ptrdiff_t, std::nullptr_t
 #include <cassert> // assert

--- a/include/bit/memory/utilities/pointer_utilities.hpp
+++ b/include/bit/memory/utilities/pointer_utilities.hpp
@@ -1,11 +1,32 @@
-/**
- * \file pointer_utilities.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines various pointer utilities to simplify deriving
  *        pointers
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_POINTER_UTILITIES_HPP
 #define BIT_MEMORY_UTILITIES_POINTER_UTILITIES_HPP
 

--- a/include/bit/memory/utilities/unaligned_storage.hpp
+++ b/include/bit/memory/utilities/unaligned_storage.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_UTILITIES_UNALIGNED_STORAGE_HPP
 #define BIT_MEMORY_UTILITIES_UNALIGNED_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <cstdint>     // std::uint8_t, std::uint16_t, etc
 #include <cstring>     // std::memcpy
 #include <memory>      // std::addressof

--- a/include/bit/memory/utilities/unaligned_storage.hpp
+++ b/include/bit/memory/utilities/unaligned_storage.hpp
@@ -1,10 +1,31 @@
-/**
- * \file unaligned_memory.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header contains various utilities for loading unaligned memory
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_UNALIGNED_STORAGE_HPP
 #define BIT_MEMORY_UTILITIES_UNALIGNED_STORAGE_HPP
 

--- a/include/bit/memory/utilities/uninitialized_storage.hpp
+++ b/include/bit/memory/utilities/uninitialized_storage.hpp
@@ -1,10 +1,31 @@
-/**
- * \file uninitialized_storage.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This header defines various uninitialized storage functionality
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_UTILITIES_UNINITIALIZED_STORAGE_HPP
 #define BIT_MEMORY_UTILITIES_UNINITIALIZED_STORAGE_HPP
 

--- a/include/bit/memory/utilities/uninitialized_storage.hpp
+++ b/include/bit/memory/utilities/uninitialized_storage.hpp
@@ -29,6 +29,10 @@
 #ifndef BIT_MEMORY_UTILITIES_UNINITIALIZED_STORAGE_HPP
 #define BIT_MEMORY_UTILITIES_UNINITIALIZED_STORAGE_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #include <tuple>   // std::forward_as_tuple, std::tuple
 #include <utility> // std::forward
 #include <cstddef> // std::size_t

--- a/src/bit/memory/regions/win32/windows.hpp
+++ b/src/bit/memory/regions/win32/windows.hpp
@@ -31,6 +31,10 @@
 #ifndef BIT_MEMORY_REGIONS_WIN32_WINDOWS_HPP
 #define BIT_MEMORY_REGIONS_WIN32_WINDOWS_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
 #ifdef _WIN32_WINDOWS
 # undef _WIN32_WINDOWS
 #endif

--- a/src/bit/memory/regions/win32/windows.hpp
+++ b/src/bit/memory/regions/win32/windows.hpp
@@ -1,12 +1,33 @@
-/**
- * \file windows.hpp
- *
+/*****************************************************************************
+ * \file
  * \brief This is an internal header that is used to include windows.h with
  *        the appropriate macro definitions
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
 
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
 #ifndef BIT_MEMORY_REGIONS_WIN32_WINDOWS_HPP
 #define BIT_MEMORY_REGIONS_WIN32_WINDOWS_HPP
 

--- a/test/bit/memory/allocators/allocator_reference.test.cpp
+++ b/test/bit/memory/allocators/allocator_reference.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file allocator_reference.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the allocator_reference
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/allocators/allocator_reference.hpp>
 #include <bit/memory/utilities/allocator_info.hpp>

--- a/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/aligned_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file aligned_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the aligned_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/aligned_block_allocator.hpp>
 #include <bit/memory/utilities/pointer_utilities.hpp> // align_of

--- a/test/bit/memory/block_allocators/block_allocator_reference.test.cpp
+++ b/test/bit/memory/block_allocators/block_allocator_reference.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file block_allocator_reference.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the block_allocator_reference
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/block_allocator_reference.hpp>
 #include <bit/memory/utilities/allocator_info.hpp>

--- a/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_aligned_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file growing_aligned_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the growing_aligned_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/growing_aligned_block_allocator.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>

--- a/test/bit/memory/block_allocators/growing_malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_malloc_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file growing_malloc_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the growing_malloc_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/growing_malloc_block_allocator.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>

--- a/test/bit/memory/block_allocators/growing_new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_new_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file growing_new_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the growing_new_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/growing_new_block_allocator.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>

--- a/test/bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/growing_virtual_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file growing_virtual_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the growing_virtual_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/growing_virtual_block_allocator.hpp>
 #include <bit/memory/regions/virtual_memory.hpp>

--- a/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/malloc_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file malloc_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the malloc_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/malloc_block_allocator.hpp>
 #include <bit/memory/concepts/Stateless.hpp>

--- a/test/bit/memory/block_allocators/new_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/new_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file new_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the new_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/new_block_allocator.hpp>
 #include <bit/memory/concepts/Stateless.hpp>

--- a/test/bit/memory/block_allocators/null_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/null_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file null_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the null_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/null_block_allocator.hpp>
 #include <bit/memory/concepts/Stateless.hpp>

--- a/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/stack_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file stack_block_allocators.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the stack_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/stack_block_allocator.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>

--- a/test/bit/memory/block_allocators/static_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/static_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file static_block_allocators.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the static_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/static_block_allocator.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>

--- a/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/thread_local_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
-* \file thread_local_block_allocators.test.cpp
- *
+/*****************************************************************************
+* \file
  * \brief Unit tests for the thread_local_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/thread_local_block_allocator.hpp>
 #include <bit/memory/concepts/BlockAllocator.hpp>

--- a/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
+++ b/test/bit/memory/block_allocators/virtual_block_allocator.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file virtual_block_allocator.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the virtual_block_allocator
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/block_allocators/virtual_block_allocator.hpp>
 #include <bit/memory/regions/virtual_memory.hpp>

--- a/test/bit/memory/utilities/endian.test.cpp
+++ b/test/bit/memory/utilities/endian.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file endian.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the header 'endian.hpp'
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/utilities/endian.hpp>
 

--- a/test/bit/memory/utilities/memory_block_cache.test.cpp
+++ b/test/bit/memory/utilities/memory_block_cache.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file memory_block_cache.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Unit tests for the memory_block_cache
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #include <bit/memory/utilities/memory_block_cache.hpp>
 #include <bit/memory/block_allocators/new_block_allocator.hpp>

--- a/test/main.test.cpp
+++ b/test/main.test.cpp
@@ -1,10 +1,8 @@
-/**
- * \file main.test.cpp
- *
+/*****************************************************************************
+ * \file
  * \brief Main unit test to dispatch into the other unit tests.
- *
- * \author Matthew Rodusek (matthew.rodusek@gmail.com)
- */
+ *****************************************************************************/
+
 
 #define CATCH_CONFIG_MAIN
 #include <catch.hpp>


### PR DESCRIPTION
### Objectives

* **Updates Doxygen formatting**
The documentation formatting has been changed to match
the formatting in `bit::stl`

* **Update each header to use `#pragma once`**
Each header now conditionally uses `#pragma once`

* **Add legal notice to each header**
Each header has been updated to include an MIT legal notice