### PR TITLE
Remove equality requirement for allocators

### DIFF
--- a/include/bit/memory/allocators/aligned_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_allocator.hpp
@@ -130,20 +130,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    /// \{
-    /// \brief Compares equality between two aligned_allocator
-    ///
-    /// Two aligned_allocator are always considered the same
-    bool operator==( const aligned_allocator& lhs,
-                     const aligned_allocator& rhs ) noexcept;
-    bool operator!=( const aligned_allocator& lhs,
-                     const aligned_allocator& rhs ) noexcept;
-    /// \}
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/allocators/aligned_offset_allocator.hpp
+++ b/include/bit/memory/allocators/aligned_offset_allocator.hpp
@@ -133,20 +133,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    /// \{
-    /// \brief Compares equality between two aligned_allocator
-    ///
-    /// Two aligned_allocator are always considered the same
-    bool operator==( const aligned_offset_allocator& lhs,
-                     const aligned_offset_allocator& rhs ) noexcept;
-    bool operator!=( const aligned_offset_allocator& lhs,
-                     const aligned_offset_allocator& rhs ) noexcept;
-    /// \}
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/allocators/bump_down_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_allocator.hpp
@@ -154,16 +154,7 @@ namespace bit {
 
       memory_block m_block;
       void*        m_current;
-
-      friend bool operator==( const bump_down_allocator&, const bump_down_allocator& ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Comparisons
-    //-------------------------------------------------------------------------
-
-    bool operator==( const bump_down_allocator& lhs, const bump_down_allocator& rhs ) noexcept;
-    bool operator!=( const bump_down_allocator& lhs, const bump_down_allocator& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_down_lifo_allocator.hpp
@@ -158,16 +158,7 @@ namespace bit {
 
       memory_block m_block;
       void*        m_current;
-
-      friend bool operator==( const bump_down_lifo_allocator&, const bump_down_lifo_allocator& ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Comparisons
-    //-------------------------------------------------------------------------
-
-    bool operator==( const bump_down_lifo_allocator& lhs, const bump_down_lifo_allocator& rhs ) noexcept;
-    bool operator!=( const bump_down_lifo_allocator& lhs, const bump_down_lifo_allocator& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/allocators/bump_up_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_allocator.hpp
@@ -146,16 +146,7 @@ namespace bit {
 
       memory_block m_block;
       void*        m_current;
-
-      friend bool operator==( const bump_up_allocator&, const bump_up_allocator& ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Comparisons
-    //-------------------------------------------------------------------------
-
-    bool operator==( const bump_up_allocator& lhs, const bump_up_allocator& rhs ) noexcept;
-    bool operator!=( const bump_up_allocator& lhs, const bump_up_allocator& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
+++ b/include/bit/memory/allocators/bump_up_lifo_allocator.hpp
@@ -158,18 +158,7 @@ namespace bit {
 
       memory_block m_block;
       void*        m_current;
-
-      friend bool operator==( const bump_up_lifo_allocator&, const bump_up_lifo_allocator& ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Comparisons
-    //-------------------------------------------------------------------------
-
-    bool operator==( const bump_up_lifo_allocator& lhs,
-                     const bump_up_lifo_allocator& rhs ) noexcept;
-    bool operator!=( const bump_up_lifo_allocator& lhs,
-                     const bump_up_lifo_allocator& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/allocators/detail/aligned_allocator.inl
+++ b/include/bit/memory/allocators/detail/aligned_allocator.inl
@@ -31,22 +31,4 @@ inline bit::memory::allocator_info bit::memory::aligned_allocator::info()
   return {"aligned_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const aligned_allocator&,
-                                     const aligned_allocator& )
-  noexcept
-{
-  return true;
-}
-
-inline bool bit::memory::operator!=( const aligned_allocator&,
-                                     const aligned_allocator& )
-  noexcept
-{
-  return false;
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_ALIGNED_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/aligned_offset_allocator.inl
+++ b/include/bit/memory/allocators/detail/aligned_offset_allocator.inl
@@ -32,22 +32,4 @@ inline bit::memory::allocator_info bit::memory::aligned_offset_allocator::info()
   return {"aligned_offset_allocator",nullptr};
 }
 
-//-----------------------------------------------------------------------------
-// Comparators
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const aligned_offset_allocator&,
-                                     const aligned_offset_allocator& )
-  noexcept
-{
-  return true;
-}
-
-inline bool bit::memory::operator!=( const aligned_offset_allocator&,
-                                     const aligned_offset_allocator& )
-  noexcept
-{
-  return false;
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_ALIGNED_OFFSET_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/bump_down_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_down_allocator.inl
@@ -80,22 +80,4 @@ inline bit::memory::allocator_info bit::memory::bump_down_allocator::info()
   return {"bump_down_allocator",this};
 }
 
-//----------------------------------------------------------------------------
-// Comparisons
-//----------------------------------------------------------------------------
-
-bool bit::memory::operator==( const bump_down_allocator& lhs,
-                              const bump_down_allocator& rhs )
-  noexcept
-{
-  return lhs.m_current == rhs.m_current && lhs.m_block == rhs.m_block;
-}
-
-bool bit::memory::operator!=( const bump_down_allocator& lhs,
-                              const bump_down_allocator& rhs )
-  noexcept
-{
-  return !(lhs==rhs);
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_BUMP_DOWN_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/bump_down_lifo_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_down_lifo_allocator.inl
@@ -97,22 +97,4 @@ inline bit::memory::allocator_info bit::memory::bump_down_lifo_allocator::info()
   return {"bump_down_lifo_allocator",this};
 }
 
-//----------------------------------------------------------------------------
-// Comparisons
-//----------------------------------------------------------------------------
-
-bool bit::memory::operator==( const bump_down_lifo_allocator& lhs,
-                              const bump_down_lifo_allocator& rhs )
-  noexcept
-{
-  return lhs.m_current == rhs.m_current && lhs.m_block == rhs.m_block;
-}
-
-bool bit::memory::operator!=( const bump_down_lifo_allocator& lhs,
-                              const bump_down_lifo_allocator& rhs )
-  noexcept
-{
-  return !(lhs==rhs);
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_BUMP_DOWN_LIFO_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/bump_up_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_up_allocator.inl
@@ -84,22 +84,4 @@ inline bit::memory::allocator_info bit::memory::bump_up_allocator::info()
   return {"bump_up_allocator",this};
 }
 
-//----------------------------------------------------------------------------
-// Comparisons
-//----------------------------------------------------------------------------
-
-bool bit::memory::operator==( const bump_up_allocator& lhs,
-                              const bump_up_allocator& rhs )
-  noexcept
-{
-  return lhs.m_current == rhs.m_current && lhs.m_block == rhs.m_block;
-}
-
-bool bit::memory::operator!=( const bump_up_allocator& lhs,
-                              const bump_up_allocator& rhs )
-  noexcept
-{
-  return !(lhs==rhs);
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_BUMP_UP_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/bump_up_lifo_allocator.inl
+++ b/include/bit/memory/allocators/detail/bump_up_lifo_allocator.inl
@@ -96,25 +96,4 @@ inline bit::memory::allocator_info bit::memory::bump_up_lifo_allocator::info()
   return {"bump_up_lifo_allocator",this};
 }
 
-//----------------------------------------------------------------------------
-// Comparisons
-//----------------------------------------------------------------------------
-
-bool bit::memory::operator==( const bump_up_lifo_allocator& lhs,
-                              const bump_up_lifo_allocator& rhs )
-  noexcept
-{
-  return lhs.m_current == rhs.m_current && lhs.m_block == rhs.m_block;
-}
-
-bool bit::memory::operator!=( const bump_up_lifo_allocator& lhs,
-                              const bump_up_lifo_allocator& rhs )
-  noexcept
-{
-  return !(lhs==rhs);
-}
-
-
-
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_BUMP_UP_LIFO_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/malloc_allocator.inl
+++ b/include/bit/memory/allocators/detail/malloc_allocator.inl
@@ -35,22 +35,4 @@ inline bit::memory::allocator_info bit::memory::malloc_allocator::info()
   return {"malloc_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const malloc_allocator&,
-                                     const malloc_allocator& )
-  noexcept
-{
-  return true;
-}
-
-inline bool bit::memory::operator!=( const malloc_allocator&,
-                                     const malloc_allocator& )
-  noexcept
-{
-  return false;
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_MALLOC_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/new_allocator.inl
+++ b/include/bit/memory/allocators/detail/new_allocator.inl
@@ -30,22 +30,4 @@ inline bit::memory::allocator_info bit::memory::new_allocator::info()
   return {"new_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const new_allocator&,
-                                     const new_allocator& )
-  noexcept
-{
-  return true;
-}
-
-inline bool bit::memory::operator!=( const new_allocator&,
-                                     const new_allocator& )
-  noexcept
-{
-  return false;
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_NEW_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/null_allocator.inl
+++ b/include/bit/memory/allocators/detail/null_allocator.inl
@@ -55,23 +55,4 @@ inline bit::memory::allocator_info bit::memory::null_allocator::info()
   return {"null_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const null_allocator&,
-                                     const null_allocator& )
-  noexcept
-{
-  return true;
-}
-
-inline bool bit::memory::operator!=( const null_allocator&,
-                                     const null_allocator& )
-  noexcept
-{
-  return false;
-}
-
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_NULL_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/policy_allocator.inl
+++ b/include/bit/memory/allocators/detail/policy_allocator.inl
@@ -156,39 +156,4 @@ bit::memory::allocator_info
   return allocator_traits<ExtendedAllocator>::info( allocator );
 }
 
-template<typename ExtendedAllocator, typename Tagger, typename Tracker,typename Checker, typename Lock>
-inline bool bit::memory::policy_allocator<ExtendedAllocator,Tagger,Tracker,Checker,Lock>
-  ::equals( const policy_allocator& other )
-  const noexcept
-{
-  auto& lhs_allocator = get<0>( *this );
-  auto& rhs_allocator = get<0>( other );
-
-  return lhs_allocator == rhs_allocator;
-}
-
-//-----------------------------------------------------------------------------
-// Comparison
-//-----------------------------------------------------------------------------
-
-template<typename Allocator, typename Tagger, typename Tracker,typename Checker, typename Lock>
-inline bool bit::memory
-  ::operator==( const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& lhs,
-                const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& rhs )
-  noexcept
-{
-  return lhs.equals(rhs);
-}
-
-
-template<typename Allocator, typename Tagger, typename Tracker,typename Checker, typename Lock>
-inline bool bit::memory
-  ::operator!=( const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& lhs,
-                const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_POLICY_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/pool_allocator.inl
+++ b/include/bit/memory/allocators/detail/pool_allocator.inl
@@ -107,24 +107,4 @@ void bit::memory::pool_allocator::create_pool()
   }
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const pool_allocator& lhs,
-                                     const pool_allocator& rhs )
-  noexcept
-{
-  return lhs.m_freelist == rhs.m_freelist &&
-         lhs.m_block == rhs.m_block &&
-         lhs.m_chunk_size == rhs.m_chunk_size;
-}
-
-inline bool bit::memory::operator!=( const pool_allocator& lhs,
-                                     const pool_allocator& rhs )
-  noexcept
-{
-  return !(lhs==rhs);
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_POOL_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/detail/stack_allocator.inl
+++ b/include/bit/memory/allocators/detail/stack_allocator.inl
@@ -105,25 +105,4 @@ inline bit::memory::allocator_info bit::memory::stack_allocator<Size,Align>::inf
   return {"stack_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-template<std::size_t S, std::size_t A>
-inline bool bit::memory::operator==( const stack_allocator<S,A>& lhs,
-                                     const stack_allocator<S,A>& rhs )
-  noexcept
-{
-  return lhs.m_current == rhs.m_current &&
-         (&lhs.m_storage[0]) == (&rhs.m_storage[0]);
-}
-
-template<std::size_t S, std::size_t A>
-inline bool bit::memory::operator!=( const stack_allocator<S,A>& lhs,
-                                     const stack_allocator<S,A>& rhs )
-  noexcept
-{
-  return !(lhs==rhs);
-}
-
 #endif /* BIT_MEMORY_ALLOCATORS_DETAIL_STACK_ALLOCATOR_INL */

--- a/include/bit/memory/allocators/malloc_allocator.hpp
+++ b/include/bit/memory/allocators/malloc_allocator.hpp
@@ -134,20 +134,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    /// \{
-    /// \brief Compares equality between two malloc_allocators
-    ///
-    /// Two malloc_allocators are always considered the same
-    bool operator==( const malloc_allocator& lhs,
-                     const malloc_allocator& rhs ) noexcept;
-    bool operator!=( const malloc_allocator& lhs,
-                     const malloc_allocator& rhs ) noexcept;
-    /// \}
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/allocators/new_allocator.hpp
+++ b/include/bit/memory/allocators/new_allocator.hpp
@@ -134,18 +134,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    /// \{
-    /// \brief Compares equality between two new_allocators
-    ///
-    /// Two new_allocators are always considered the same
-    bool operator==( const new_allocator&, const new_allocator& ) noexcept;
-    bool operator!=( const new_allocator&, const new_allocator& ) noexcept;
-    /// \}
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/allocators/null_allocator.hpp
+++ b/include/bit/memory/allocators/null_allocator.hpp
@@ -148,20 +148,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    /// \{
-    /// \brief Compares equality between two null_allocators
-    ///
-    /// Two null_allocators are always considered the same
-    bool operator==( const null_allocator& lhs,
-                     const null_allocator& rhs ) noexcept;
-    bool operator!=( const null_allocator& lhs,
-                     const null_allocator& rhs ) noexcept;
-    /// \}
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/allocators/policy_allocator.hpp
+++ b/include/bit/memory/allocators/policy_allocator.hpp
@@ -243,36 +243,7 @@ namespace bit {
       /// \return the minimum amount of bytes able to allocated
       template<typename U = ExtendedAllocator, typename = std::enable_if_t<allocator_has_min_size<U>::value>>
       std::size_t min_size() const noexcept;
-
-      //-----------------------------------------------------------------------
-      // Private Members
-      //-----------------------------------------------------------------------
-    private:
-
-      /// \brief Determines equality between two policy allocators
-      ///
-      /// \note This function exists to circumvent an issue where casting to a
-      ///       private base-class from a friend function is illegal
-      ///
-      /// \param other the allocator to compare to
-      bool equals( const policy_allocator& other ) const noexcept;
-
-      template<typename Allocator, typename Tagger, typename Tracker,typename Checker, typename Lock>
-      friend bool operator==( const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& lhs,
-                              const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& rhs ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Comparison
-    //-------------------------------------------------------------------------
-
-    template<typename Allocator, typename Tagger, typename Tracker,typename Checker, typename Lock>
-    bool operator==( const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& lhs,
-                     const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& rhs ) noexcept;
-
-    template<typename Allocator, typename Tagger, typename Tracker,typename Checker, typename Lock>
-    bool operator!=( const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& lhs,
-                     const policy_allocator<Allocator,Tagger,Tracker,Checker,Lock>& rhs ) noexcept;
 
   } // namespace memory
 } // namespace bit

--- a/include/bit/memory/allocators/pool_allocator.hpp
+++ b/include/bit/memory/allocators/pool_allocator.hpp
@@ -161,16 +161,7 @@ namespace bit {
 
       /// \brief Creates the pool of instances to be used by the allocator
       void create_pool();
-
-      friend bool operator==( const pool_allocator&, const pool_allocator&) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    bool operator==( const pool_allocator& lhs, const pool_allocator& rhs ) noexcept;
-    bool operator!=( const pool_allocator& lhs, const pool_allocator& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/allocators/stack_allocator.hpp
+++ b/include/bit/memory/allocators/stack_allocator.hpp
@@ -150,20 +150,7 @@ namespace bit {
 
       alignas(Align) char m_storage[Size];
       void* m_current;
-
-      template<std::size_t S, std::size_t A>
-      friend bool operator==( const stack_allocator<S,A>&, const stack_allocator<S,A>& ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t S, std::size_t A>
-    bool operator==( const stack_allocator<S,A>& lhs, const stack_allocator<S,A>& rhs ) noexcept;
-
-    template<std::size_t S, std::size_t A>
-    bool operator!=( const stack_allocator<S,A>& lhs, const stack_allocator<S,A>& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/block_allocators/aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/aligned_block_allocator.hpp
@@ -230,18 +230,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t Size, std::size_t Align>
-    bool operator==( const aligned_block_allocator<Size,Align>& lhs,
-                     const aligned_block_allocator<Size,Align>& rhs ) noexcept;
-
-    template<std::size_t Size, std::size_t Align>
-    bool operator!=( const aligned_block_allocator<Size,Align>& lhs,
-                     const aligned_block_allocator<Size,Align>& rhs ) noexcept;
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/block_allocators/detail/aligned_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/aligned_block_allocator.inl
@@ -55,24 +55,4 @@ inline bit::memory::allocator_info
   return {"aligned_block_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-template<std::size_t Size, std::size_t Align>
-inline bool bit::memory::operator==( const aligned_block_allocator<Size,Align>& lhs,
-                                     const aligned_block_allocator<Size,Align>& rhs )
-  noexcept
-{
-  return lhs.next_block_size() == rhs.next_block_size();
-}
-
-template<std::size_t Size, std::size_t Align>
-inline bool bit::memory::operator!=( const aligned_block_allocator<Size,Align>& lhs,
-                                     const aligned_block_allocator<Size,Align>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_ALIGNED_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_aligned_block_allocator.inl
@@ -68,24 +68,4 @@ inline void bit::memory::growing_aligned_block_allocator<Size,Align>::grow()
   base_type::m_multiplier *= 2;
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-template<std::size_t Size, std::size_t Align>
-inline bool bit::memory::operator==( const growing_aligned_block_allocator<Size,Align>& lhs,
-                                     const growing_aligned_block_allocator<Size,Align>& rhs )
-  noexcept
-{
-  return lhs.next_block_size() == rhs.next_block_size();
-}
-
-template<std::size_t Size, std::size_t Align>
-inline bool bit::memory::operator!=( const growing_aligned_block_allocator<Size,Align>& lhs,
-                                     const growing_aligned_block_allocator<Size,Align>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_GROWING_ALIGNED_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/growing_malloc_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_malloc_block_allocator.inl
@@ -60,26 +60,4 @@ inline void bit::memory::growing_malloc_block_allocator<Size>::grow()
   base_type::m_multiplier *= 2;
 }
 
-
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-template<std::size_t Size>
-inline bool bit::memory::operator==( const growing_malloc_block_allocator<Size>& lhs,
-                                     const growing_malloc_block_allocator<Size>& rhs )
-  noexcept
-{
-  return lhs.m_growths_available == rhs.m_growths_available &&
-         lhs.m_multiplier == rhs.m_multiplier;
-}
-
-template<std::size_t Size>
-inline bool bit::memory::operator!=( const growing_malloc_block_allocator<Size>& lhs,
-                                     const growing_malloc_block_allocator<Size>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_GROWING_MALLOC_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/growing_new_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/growing_new_block_allocator.inl
@@ -60,26 +60,4 @@ inline void bit::memory::growing_new_block_allocator<Size>::grow()
   base_type::m_multiplier *= 2;
 }
 
-
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-template<std::size_t Size>
-inline bool bit::memory::operator==( const growing_new_block_allocator<Size>& lhs,
-                                     const growing_new_block_allocator<Size>& rhs )
-  noexcept
-{
-  return lhs.m_growths_available == rhs.m_growths_available &&
-         lhs.m_multiplier == rhs.m_multiplier;
-}
-
-template<std::size_t Size>
-inline bool bit::memory::operator!=( const growing_new_block_allocator<Size>& lhs,
-                                     const growing_new_block_allocator<Size>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_GROWING_NEW_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/malloc_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/malloc_block_allocator.inl
@@ -46,25 +46,4 @@ inline bit::memory::allocator_info
   return {"malloc_block_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Comparisons
-//-----------------------------------------------------------------------------
-
-template<std::size_t Size>
-inline bool bit::memory::operator==( const malloc_block_allocator<Size>& lhs,
-                                     const malloc_block_allocator<Size>& rhs )
-  noexcept
-{
-  return lhs.next_block_size() == rhs.next_block_size();
-}
-
-template<std::size_t Size>
-inline bool bit::memory::operator!=( const malloc_block_allocator<Size>& lhs,
-                                     const malloc_block_allocator<Size>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_MALLOC_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/new_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/new_block_allocator.inl
@@ -45,24 +45,4 @@ inline bit::memory::allocator_info bit::memory::new_block_allocator<Size>::info(
   return {"new_block_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Comparisons
-//-----------------------------------------------------------------------------
-
-template<std::size_t Size>
-inline bool bit::memory::operator==( const new_block_allocator<Size>& lhs,
-                                     const new_block_allocator<Size>& rhs )
-  noexcept
-{
-  return lhs.next_block_size() == rhs.next_block_size();
-}
-
-template<std::size_t Size>
-inline bool bit::memory::operator!=( const new_block_allocator<Size>& lhs,
-                                     const new_block_allocator<Size>& rhs )
-  noexcept
-{
-  return !(lhs == rhs);
-}
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_NEW_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/detail/null_block_allocator.inl
+++ b/include/bit/memory/block_allocators/detail/null_block_allocator.inl
@@ -35,22 +35,4 @@ inline bit::memory::allocator_info  bit::memory::null_block_allocator::info()
   return {"null_allocator",this};
 }
 
-//-----------------------------------------------------------------------------
-// Equality
-//-----------------------------------------------------------------------------
-
-inline bool bit::memory::operator==( const null_block_allocator&,
-                                     const null_block_allocator& )
-  noexcept
-{
-  return true;
-}
-
-inline bool bit::memory::operator!=( const null_block_allocator&,
-                                     const null_block_allocator& )
-  noexcept
-{
-  return false;
-}
-
 #endif /* BIT_MEMORY_BLOCK_ALLOCATORS_DETAIL_NULL_BLOCK_ALLOCATOR_INL */

--- a/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_aligned_block_allocator.hpp
@@ -242,18 +242,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t Size, std::size_t Align>
-    bool operator==( const growing_aligned_block_allocator<Size,Align>& lhs,
-                     const growing_aligned_block_allocator<Size,Align>& rhs ) noexcept;
-
-    template<std::size_t Size, std::size_t Align>
-    bool operator!=( const growing_aligned_block_allocator<Size,Align>& lhs,
-                     const growing_aligned_block_allocator<Size,Align>& rhs ) noexcept;
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_malloc_block_allocator.hpp
@@ -188,23 +188,7 @@ namespace bit {
 
       /// \brief Grows the size of each block, if possible
       void grow();
-
-      template<std::size_t S>
-      friend bool operator==( const growing_malloc_block_allocator<S>&,
-                              const growing_malloc_block_allocator<S>& rhs ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t Size>
-    bool operator==( const growing_malloc_block_allocator<Size>& lhs,
-                     const growing_malloc_block_allocator<Size>& rhs ) noexcept;
-
-    template<std::size_t Size>
-    bool operator!=( const growing_malloc_block_allocator<Size>& lhs,
-                     const growing_malloc_block_allocator<Size>& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/growing_new_block_allocator.hpp
@@ -188,23 +188,7 @@ namespace bit {
 
       /// \brief Grows the size of each block, if possible
       void grow();
-
-      template<std::size_t S>
-      friend bool operator==( const growing_new_block_allocator<S>&,
-                              const growing_new_block_allocator<S>& rhs ) noexcept;
     };
-
-    //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t Size>
-    bool operator==( const growing_new_block_allocator<Size>& lhs,
-                     const growing_new_block_allocator<Size>& rhs ) noexcept;
-
-    template<std::size_t Size>
-    bool operator!=( const growing_new_block_allocator<Size>& lhs,
-                     const growing_new_block_allocator<Size>& rhs ) noexcept;
 
     //-------------------------------------------------------------------------
     // Utilities

--- a/include/bit/memory/block_allocators/malloc_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/malloc_block_allocator.hpp
@@ -171,18 +171,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t Size>
-    bool operator==( const malloc_block_allocator<Size>& lhs,
-                     const malloc_block_allocator<Size>& rhs ) noexcept;
-
-    template<std::size_t Size>
-    bool operator!=( const malloc_block_allocator<Size>& lhs,
-                     const malloc_block_allocator<Size>& rhs ) noexcept;
-
-    //-------------------------------------------------------------------------
     // Utiltiies
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/block_allocators/new_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/new_block_allocator.hpp
@@ -183,18 +183,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    template<std::size_t S>
-    bool operator==( const new_block_allocator<S>& lhs,
-                     const new_block_allocator<S>& rhs ) noexcept;
-
-    template<std::size_t S>
-    bool operator!=( const new_block_allocator<S>& lhs,
-                     const new_block_allocator<S>& rhs ) noexcept;
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/block_allocators/null_block_allocator.hpp
+++ b/include/bit/memory/block_allocators/null_block_allocator.hpp
@@ -128,15 +128,6 @@ namespace bit {
     };
 
     //-------------------------------------------------------------------------
-    // Equality
-    //-------------------------------------------------------------------------
-
-    bool operator==( const null_block_allocator& lhs,
-                     const null_block_allocator& rhs ) noexcept;
-    bool operator!=( const null_block_allocator& lhs,
-                     const null_block_allocator& rhs ) noexcept;
-
-    //-------------------------------------------------------------------------
     // Utilities
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/concepts/Allocator.hpp
+++ b/include/bit/memory/concepts/Allocator.hpp
@@ -100,24 +100,6 @@ namespace bit {
     ///
     /// - - - - -
     ///
-    /// \code
-    /// a1 == a2
-    /// \endcode
-    ///
-    /// returns true only if the storage allocated by the allocator a1 can be
-    /// deallocated through a2. Establishes reflexive, symmetric, and
-    /// transitive relationship. Does not throw exceptions.
-    ///
-    /// - - - - -
-    ///
-    /// \code
-    /// a1 != a2
-    /// \endcode
-    ///
-    /// same as !(a1==a2)
-    ///
-    /// - - - - -
-    ///
     /// **Optionally**
     ///
     /// \code


### PR DESCRIPTION
The requirement for allocators and block_allocators to have
equality operators has been lifted. For 2 allocators to ever
be considered equal, they must both manage the same underlying
memory, at the same state. Since every allocator uniquely owns
the memory in which it points to, the only way for this equality
to ever be true is for the allocator to be comparing against itself.