### PR TITLE
Extend Allocator Traits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(headers
   # Traits
   include/bit/memory/traits/allocator_traits.hpp
   include/bit/memory/traits/block_allocator_traits.hpp
+  include/bit/memory/traits/extended_allocator_traits.hpp
 
   # Regions
   include/bit/memory/regions/aligned_heap_memory.hpp
@@ -186,6 +187,7 @@ set(inline_headers
   # Traits
   include/bit/memory/traits/detail/allocator_traits.inl
   include/bit/memory/traits/detail/block_allocator_traits.inl
+  include/bit/memory/traits/detail/extended_allocator_traits.inl
 
   # Regions
   include/bit/memory/regions/detail/virtual_memory.inl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ make_version_header("${CMAKE_CURRENT_BINARY_DIR}/include/bit/memory/version.hpp"
 
 set(headers
   # Utilities
+  include/bit/memory/utilities/address.hpp
   include/bit/memory/utilities/allocator_info.hpp
   include/bit/memory/utilities/debugging.hpp
   include/bit/memory/utilities/dynamic_size_type.hpp
@@ -168,6 +169,7 @@ set(headers
 # this is added for IDEs like CLion to accurately track headers.
 set(inline_headers
   # Utilities
+  include/bit/memory/utilities/detail/address.inl
   include/bit/memory/utilities/detail/allocator_info.inl
   include/bit/memory/utilities/detail/debugging.inl
   include/bit/memory/utilities/detail/dynamic_size_type.inl
@@ -350,9 +352,9 @@ endif()
 # bit::memory : Benchmarks
 #-----------------------------------------------------------------------------
 
-if( BIT_MEMORY_COMPILE_BENCHMARKS )
-  add_subdirectory(benchmarks)
-endif()
+# if( BIT_MEMORY_COMPILE_BENCHMARKS )
+#   add_subdirectory(benchmarks)
+# endif()
 
 #-----------------------------------------------------------------------------
 # bit::memory : Documentation

--- a/include/bit/memory/concepts/Allocator.hpp
+++ b/include/bit/memory/concepts/Allocator.hpp
@@ -446,6 +446,19 @@ namespace bit {
         void_t<decltype(T::max_alignment)>>
         : std::integral_constant<allocator_size_type_t<T>,alignof(std::max_align_t)>{};
 
+      //----------------------------------------------------------------------
+
+      template<typename T, typename = void>
+      struct allocator_has_expand : std::false_type{};
+
+      template<typename T>
+      struct allocator_has_expand<T,
+        void_t<decltype(std::declval<bool&>()
+          = std::declval<T&>().expand( std::declval<allocator_pointer_t<T>&>(),
+                                       std::declval<allocator_size_type_t<T>>() ))
+        >
+      > : std::true_type{};
+
     } // namespace detail
 
     /// \brief Type-trait to determine whether \p T has a 'try_allocate'
@@ -785,6 +798,25 @@ namespace bit {
     /// \tparam T the type to check
     template<typename T>
     constexpr allocator_size_type_t<T> allocator_max_alignment_v = allocator_max_alignment<T>::value;
+
+    //-------------------------------------------------------------------------
+
+    /// \brief Type trait to determine whether the allocator has the expand
+    ///        function
+    ///
+    /// The result is aliased as \c ::value
+    ///
+    /// \tparam T the type to check
+    template<typename T>
+    struct allocator_has_expand
+      : detail::allocator_has_expand<T>{};
+
+    /// \brief Convenience template bool for accessing
+    ///        \c allocator_has_expand<T>::value
+    ///
+    /// \tparam T the type to check
+    template<typename T>
+    constexpr bool allocator_has_expand_v = allocator_has_expand<T>::value;
 
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/concepts/ExtendedAllocator.hpp
+++ b/include/bit/memory/concepts/ExtendedAllocator.hpp
@@ -156,19 +156,6 @@ namespace bit {
          >
        > : std::true_type{};
 
-      //-----------------------------------------------------------------------
-
-      template<typename T, typename = void>
-      struct allocator_has_expand : std::false_type{};
-
-      template<typename T>
-      struct allocator_has_expand<T,
-        void_t<decltype(std::declval<bool&>()
-          = std::declval<T&>().expand( std::declval<allocator_pointer_t<T>&>(),
-                                       std::declval<allocator_size_type_t<T>>() ))
-        >
-      > : std::true_type{};
-
     } // namespace detail
 
     /// \brief Type trait to determine whether the allocator has the extended
@@ -227,25 +214,6 @@ namespace bit {
     template<typename T>
     constexpr bool allocator_has_extended_allocate_hint_v
       = allocator_has_extended_allocate_hint<T>::value;
-
-    //-------------------------------------------------------------------------
-
-    /// \brief Type trait to determine whether the allocator has the expand
-    ///        function
-    ///
-    /// The result is aliased as \c ::value
-    ///
-    /// \tparam T the type to check
-    template<typename T>
-    struct allocator_has_expand
-      : detail::allocator_has_expand<T>{};
-
-    /// \brief Convenience template bool for accessing
-    ///        \c allocator_has_expand<T>::value
-    ///
-    /// \tparam T the type to check
-    template<typename T>
-    constexpr bool allocator_has_expand_v = allocator_has_expand<T>::value;
 
     //-------------------------------------------------------------------------
 

--- a/include/bit/memory/traits/detail/extended_allocator_traits.inl
+++ b/include/bit/memory/traits/detail/extended_allocator_traits.inl
@@ -1,0 +1,241 @@
+#ifndef BIT_MEMORY_TRAITS_DETAIL_EXTENDED_ALLOCATOR_TRAITS_INL
+#define BIT_MEMORY_TRAITS_DETAIL_EXTENDED_ALLOCATOR_TRAITS_INL
+
+namespace bit { namespace memory { namespace detail {
+
+  template<typename Allocator>
+  struct extended_allocator_traits_impl
+  {
+    //-------------------------------------------------------------------------
+    // Public Types
+    //-------------------------------------------------------------------------
+
+    using traits_type   = extended_allocator_traits<Allocator>;
+    using pointer       = typename traits_type::pointer;
+    using const_pointer = typename traits_type::const_pointer;
+
+    using size_type = typename traits_type::size_type;
+
+    template<typename T>
+    using pointer_rebind = typename traits_type::template pointer_rebind<T>;
+
+    //-------------------------------------------------------------------------
+    // Private Allocations
+    //-------------------------------------------------------------------------
+
+    static pointer do_extended_try_allocate_hint( std::true_type,
+                                                  Allocator& alloc,
+                                                  const_pointer p,
+                                                  size_type size,
+                                                  size_type align,
+                                                  size_type offset );
+    static pointer do_extended_try_allocate_hint( std::false_type,
+                                                  Allocator& alloc,
+                                                  const_pointer p,
+                                                  size_type size,
+                                                  size_type align,
+                                                  size_type offset );
+
+    //-------------------------------------------------------------------------
+
+    static pointer do_extended_allocate( std::true_type,
+                                         Allocator& alloc,
+                                         size_type size,
+                                         size_type align,
+                                         size_type offset );
+    static pointer do_extended_allocate( std::false_type,
+                                         Allocator& alloc,
+                                         size_type size,
+                                         size_type align,
+                                         size_type offset );
+
+
+    //-------------------------------------------------------------------------
+
+    static pointer do_extended_allocate_hint( std::true_type,
+                                              Allocator& alloc,
+                                              const_pointer p,
+                                              size_type size,
+                                              size_type align,
+                                              size_type offset );
+    static pointer do_extended_allocate_hint( std::false_type,
+                                              Allocator& alloc,
+                                              const_pointer p,
+                                              size_type size,
+                                              size_type align,
+                                              size_type offset );
+
+  };
+
+} } } // namespace bit::memory::detail
+
+//-----------------------------------------------------------------------------
+// Allocations
+//-----------------------------------------------------------------------------
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::extended_allocator_traits<Allocator>
+  ::try_allocate( Allocator& alloc,
+                  size_type size,
+                  size_type align,
+                  size_type offset )
+  noexcept
+{
+  return alloc.try_allocate( size, align, offset );
+}
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::extended_allocator_traits<Allocator>
+  ::try_allocate( Allocator& alloc,
+                  const_pointer hint,
+                  size_type size,
+                  size_type align,
+                  size_type offset )
+  noexcept
+{
+  using impl_type = detail::extended_allocator_traits_impl<Allocator>;
+
+  static constexpr auto tag = allocator_has_extended_try_allocate_hint<Allocator>{};
+
+  return impl_type::do_extended_try_allocate_hint( tag, size, align, offset );
+}
+
+
+//-----------------------------------------------------------------------------
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::extended_allocator_traits<Allocator>
+  ::allocate( Allocator& alloc,
+              size_type size,
+              size_type align,
+              size_type offset )
+{
+  using impl_type = detail::extended_allocator_traits_impl<Allocator>;
+
+  static constexpr auto tag = allocator_has_extended_allocate<Allocator>{};
+
+  return impl_type::do_extended_allocate( tag, alloc, size, align, offset );
+}
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::extended_allocator_traits<Allocator>
+  ::allocate( Allocator& alloc,
+              const_pointer p,
+              size_type size,
+              size_type align,
+              size_type offset )
+{
+  using impl_type = detail::extended_allocator_traits_impl<Allocator>;
+
+  static constexpr auto tag = allocator_has_extended_allocate_hint<Allocator>{};
+
+  return impl_type::do_extended_allocate_hint( tag, alloc, size, align, offset );
+}
+
+//-----------------------------------------------------------------------------
+// Private Allocations
+//-----------------------------------------------------------------------------
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::detail::extended_allocator_traits_impl<Allocator>
+  ::do_extended_try_allocate_hint( std::true_type,
+                                   Allocator& alloc,
+                                   const_pointer hint,
+                                   size_type size,
+                                   size_type align,
+                                   size_type offset )
+{
+  return alloc.try_allocate( hint, size, align, offset );
+}
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::detail::extended_allocator_traits_impl<Allocator>
+  ::do_extended_try_allocate_hint( std::false_type,
+                                   Allocator& alloc,
+                                   const_pointer hint,
+                                   size_type size,
+                                   size_type align,
+                                   size_type offset )
+{
+  BIT_MEMORY_UNUSED(hint);
+
+  return traits_type::try_allocate( alloc, size, align, offset );
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::detail::extended_allocator_traits_impl<Allocator>
+  ::do_extended_allocate( std::true_type,
+                          Allocator& alloc,
+                          size_type size,
+                          size_type align,
+                          size_type offset )
+{
+  return alloc.allocate( size, align, offset );
+}
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::detail::extended_allocator_traits_impl<Allocator>
+  ::do_extended_allocate( std::false_type,
+                          Allocator& alloc,
+                          size_type size,
+                          size_type align,
+                          size_type offset )
+{
+  auto p = traits_type::try_allocate( alloc, size, align, offset );
+
+  // Assume null allocations are unlikely, since they are the expensive
+  // code-path to manage
+  if( BIT_MEMORY_UNLIKELY(p == nullptr) ) {
+    const auto info = traits_type::info( alloc );
+
+    (*get_out_of_memory_handler())(info, size);
+
+    // Invoking the out-of-memory handler must not return
+    BIT_MEMORY_UNREACHABLE();
+  }
+
+  return p;
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::detail::extended_allocator_traits_impl<Allocator>
+  ::do_extended_allocate_hint( std::true_type,
+                               Allocator& alloc,
+                               const_pointer hint,
+                               size_type size,
+                               size_type align,
+                               size_type offset )
+{
+  return alloc.allocate( hint, size, align, offset );
+}
+
+template<typename Allocator>
+inline typename bit::memory::extended_allocator_traits<Allocator>::pointer
+  bit::memory::detail::extended_allocator_traits_impl<Allocator>
+  ::do_extended_allocate_hint( std::false_type,
+                               Allocator& alloc,
+                               const_pointer hint,
+                               size_type size,
+                               size_type align,
+                               size_type offset )
+{
+  BIT_MEMORY_UNUSED(hint);
+
+  return traits_type::allocate( alloc, size, align, offset );
+}
+
+
+#endif /* BIT_MEMORY_TRAITS_DETAIL_EXTENDED_ALLOCATOR_TRAITS_INL */

--- a/include/bit/memory/traits/extended_allocator_traits.hpp
+++ b/include/bit/memory/traits/extended_allocator_traits.hpp
@@ -1,0 +1,149 @@
+/*****************************************************************************
+ * \file
+ * \brief This header contains the trait type \c extended_allocator_traits that
+ *        provides access to capabilities required for an extended allocator
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+#ifndef BIT_MEMORY_TRAITS_EXTENDED_ALLOCATOR_TRAITS_HPP
+#define BIT_MEMORY_TRAITS_EXTENDED_ALLOCATOR_TRAITS_HPP
+
+#include "allocator_traits.hpp"
+
+#include "../utilities/allocator_info.hpp" // allocator_info
+#include "../utilities/errors.hpp"         // get_out_of_memory_handler
+#include "../utilities/macros.hpp"         // BIT_MEMORY_UNUSED
+
+#include "../concepts/ExtendedAllocator.hpp" // allocator_has_extended_try_allocate
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+namespace bit {
+  namespace memory {
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief The extended_allocator_traits class template provides a
+    ///        standardized way to access the extneded allocator functionality
+    ///
+    /// This extends the existing functionality of 'allocator_traits' by
+    /// including extended allocation facilities which allow for offset
+    /// allocations.
+    ///
+    /// \tparam Allocator the allocator type. Must satisfy ExtendedAllocator
+    ///                   concept
+    ///////////////////////////////////////////////////////////////////////////
+    template<typename Allocator>
+    class extended_allocator_traits : public allocator_traits<Allocator>
+    {
+      using base_type = allocator_traits<Allocator>;
+
+      static_assert( is_extended_allocator<Allocator>::value,
+                     "Allocator must be an ExtendedAllocator" );
+
+      //-----------------------------------------------------------------------
+      // Public Members
+      //-----------------------------------------------------------------------
+    public:
+
+      // aliases
+      using pointer         = typename base_type::pointer;
+      using const_pointer   = typename base_type::const_pointer;
+      using size_type       = typename base_type::size_type;
+      using difference_type = typename base_type::difference_type;
+
+      // rebinding
+      template<typename T>
+      using pointer_rebind = typename base_type::template pointer_rebind<T>;
+
+      // properties
+      using default_alignment          = typename base_type::default_alignment;
+      using max_alignment              = typename base_type::max_alignment;
+      using can_truncate_deallocations = typename base_type::can_truncate_deallocations;
+      using knows_ownership            = typename base_type::knows_ownership;
+      using uses_pretty_pointers       = typename base_type::uses_pretty_pointers;
+
+      //-----------------------------------------------------------------------
+      // Allocation
+      //-----------------------------------------------------------------------
+    public:
+
+      /// \{
+      /// \brief Attempts to allocate memory of at least \p size bytes,
+      ///        aligned to \p align boundary with an offset of \p offset bytes
+      ///
+      /// On failure, this function returns \p nullptr
+      ///
+      /// \param alloc the allocator to allocate from
+      /// \param hint pointer to a nearby memory location to allocate near
+      /// \param size the size of the allocation
+      /// \param align the alignment of the allocation
+      /// \param offset the offset of the allocation
+      /// \return the pointer to the allocated memory
+      static pointer try_allocate( Allocator& alloc,
+                                   size_type size,
+                                   size_type align,
+                                   size_type offset ) noexcept;
+      static pointer try_allocate( Allocator& alloc,
+                                   const_pointer hint,
+                                   size_type size,
+                                   size_type align,
+                                   size_type offset ) noexcept;
+      /// \}
+
+      //-----------------------------------------------------------------------
+
+      /// \{
+      /// \brief Allocates memory of at least \p size bytes, aligned to \p
+      ///        align boundary with an offset of \p offset bytes
+      ///
+      /// On failure, this function may throw or invoke the out_of_memory
+      /// handler before returning \p nullptr
+      ///
+      /// \param alloc the allocator to allocate from
+      /// \param hint pointer to a nearby memory location to allocate near
+      /// \param size the size of the allocation
+      /// \param align the alignment of the allocation
+      /// \param offset the offset of the allocation
+      /// \return the pointer to the allocated member
+      static pointer allocate( Allocator& alloc,
+                               size_type size,
+                               size_type align,
+                               size_type offset );
+      static pointer allocate( Allocator& alloc,
+                               const_pointer hint,
+                               size_type size,
+                               size_type align,
+                               size_type offset );
+      /// \}
+    };
+
+  } // namespace memory
+} // namespace bit
+
+#include "detail/extended_allocator_traits.inl"
+
+#endif /* BIT_MEMORY_TRAITS_EXTENDED_ALLOCATOR_TRAITS_HPP */

--- a/include/bit/memory/utilities/address.hpp
+++ b/include/bit/memory/utilities/address.hpp
@@ -1,0 +1,269 @@
+/*****************************************************************************
+ * \file
+ * \brief TODO: Add description
+ *****************************************************************************/
+
+/*
+  The MIT License (MIT)
+
+  Copyright (c) 2018 Matthew Rodusek
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+
+#ifndef BIT_MEMORY_UTILITIES_ADDRESS_HPP
+#define BIT_MEMORY_UTILITIES_ADDRESS_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include <cstdint>
+#include <type_traits>
+
+namespace bit {
+  namespace memory {
+
+    //=========================================================================
+    // address
+    //=========================================================================
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief An integral type representing a memory address.
+    ///
+    /// Addresses are comparable, and have restricted arithmetic operators
+    /// to only support:
+    ///
+    /// - addition of integers
+    /// - subtraction of integers
+    /// - bitwise operations of integers or other addresses
+    ///////////////////////////////////////////////////////////////////////////
+    enum class address : std::uintptr_t{};
+
+    //-------------------------------------------------------------------------
+    // Compound Operators
+    //-------------------------------------------------------------------------
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    address& operator+=( address& lhs, IntT rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    address& operator-=( address& lhs, IntT rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    address& operator&=( address& lhs, address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    address& operator&=( address& lhs, IntT rhs ) noexcept;
+
+    address& operator|=( address& lhs, address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    address& operator|=( address& lhs, IntT rhs ) noexcept;
+
+    address& operator^=( address& lhs, address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    address& operator^=( address& lhs, IntT rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+    // Binary Operators
+    //-------------------------------------------------------------------------
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr address operator+( address lhs, IntT rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr address operator+( IntT lhs, address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr address operator-( address lhs, IntT rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    constexpr address operator~( address lhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr address operator&( address lhs, IntT rhs ) noexcept;
+    constexpr address operator&( address lhs, address rhs ) noexcept;
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr address operator|( address lhs, IntT rhs ) noexcept;
+    constexpr address operator|( address lhs, address rhs ) noexcept;
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr address operator^( address lhs, IntT rhs ) noexcept;
+    constexpr address operator^( address lhs, address rhs ) noexcept;
+
+    //=========================================================================
+    // X.Y.2 : enum class const_address
+    //=========================================================================
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief An integral type representing a constant memory address.
+    ///
+    /// Like address, const_address objects are comparable, and have
+    /// restricted arithmetic operators to only support:
+    ///
+    /// - addition of integers,
+    /// - subtraction of integers, and
+    /// - bitwise operations of integers or other addresses.
+    ///
+    /// const_address exists independent of address to ensure that the two
+    /// are unable to be used in expressions together, except when used for
+    /// comparisons.
+    ///
+    /// This distinction allows for better type safety when using addresses
+    /// in expressions containing both const-qualified and const-unqualified
+    /// objects.
+    /// Otherwise,
+    ///////////////////////////////////////////////////////////////////////////
+    enum class const_address : std::uintptr_t{};
+
+    //-------------------------------------------------------------------------
+    // Compound Operators
+    //-------------------------------------------------------------------------
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    const_address& operator+=( const_address& lhs, IntT rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    const_address& operator-=( const_address& lhs, IntT rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    const_address& operator&=( const_address& lhs, const_address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    const_address& operator&=( const_address& lhs, IntT rhs ) noexcept;
+
+    const_address& operator|=( const_address& lhs, const_address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    const_address& operator|=( const_address& lhs, IntT rhs ) noexcept;
+
+    const_address& operator^=( const_address& lhs, const_address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    const_address& operator^=( const_address& lhs, IntT rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+    // Binary Operators
+    //-------------------------------------------------------------------------
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr const_address operator+( const_address lhs, IntT rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr const_address operator+( IntT lhs, const_address rhs ) noexcept;
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr const_address operator-( const_address lhs, IntT rhs ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    constexpr const_address operator~( const_address x ) noexcept;
+
+    //-------------------------------------------------------------------------
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr const_address operator&( const_address lhs, IntT rhs ) noexcept;
+    constexpr const_address operator&( const_address lhs,
+                                       const_address rhs ) noexcept;
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr const_address operator|( const_address lhs, IntT rhs ) noexcept;
+    constexpr const_address operator|( const_address lhs,
+                                       const_address rhs ) noexcept;
+
+    template<typename IntT,
+             typename = std::enable_if_t<std::is_integral<IntT>::value>>
+    constexpr const_address operator^( const_address lhs, IntT rhs ) noexcept;
+    constexpr const_address operator^( const_address lhs,
+                                       const_address rhs ) noexcept;
+
+    //=========================================================================
+    // X.Y.3 : address/const_address utilities
+    //=========================================================================
+
+    /// \{
+    /// \brief Converts a pointer to an address
+    ///
+    /// \param p the pointer
+    /// \return the converted address
+    address to_address( void* p ) noexcept;
+    const_address to_address( const void* p ) noexcept;
+    /// \}
+
+    /// \{
+    /// \brief Converts an address to a pointer
+    ///
+    /// \param a the address
+    /// \return the pointer for the address
+    void* to_pointer( address a ) noexcept;
+    const void* to_pointer( const_address a ) noexcept;
+    /// \}
+
+    /// \{
+    /// \brief Converts an address into a pointer of type \p T
+    ///
+    /// \tparam T the type to convert the pointer into
+    /// \param a the address
+    /// \return the pointer for the address
+    template<typename T>
+    T* to_pointer( address a ) noexcept;
+    template<typename T>
+    const T* to_pointer( const_address a ) noexcept;
+    /// \}
+
+    //=========================================================================
+    // X.Y.4 : address/const_address comparisons
+    //=========================================================================
+
+    constexpr bool operator==( address lhs, const_address rhs ) noexcept;
+    constexpr bool operator==( const_address lhs, address rhs ) noexcept;
+    constexpr bool operator!=( address lhs, const_address rhs ) noexcept;
+    constexpr bool operator!=( const_address lhs, address rhs ) noexcept;
+    constexpr bool operator<( address lhs, const_address rhs ) noexcept;
+    constexpr bool operator<( const_address lhs, address rhs ) noexcept;
+    constexpr bool operator>( address lhs, const_address rhs ) noexcept;
+    constexpr bool operator>( const_address lhs, address rhs ) noexcept;
+    constexpr bool operator<=( address lhs, const_address rhs ) noexcept;
+    constexpr bool operator<=( const_address lhs, address rhs ) noexcept;
+    constexpr bool operator>=( address lhs, const_address rhs ) noexcept;
+    constexpr bool operator>=( const_address lhs, address rhs ) noexcept;
+
+  } // namespace memory
+} // namespace bit
+
+#include "detail/address.inl"
+
+#endif /* BIT_MEMORY_UTILITIES_ADDRESS_HPP */

--- a/include/bit/memory/utilities/detail/address.inl
+++ b/include/bit/memory/utilities/detail/address.inl
@@ -1,0 +1,446 @@
+#ifndef BIT_MEMORY_UTILITIES_DETAIL_ADDRESS_INL
+#define BIT_MEMORY_UTILITIES_DETAIL_ADDRESS_INL
+
+//=============================================================================
+// X.Y.1 : enum class address
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Compound Operators
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline bit::memory::address&
+  bit::memory::operator+=( address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) + rhs );
+}
+
+template<typename IntT, typename>
+inline bit::memory::address&
+  bit::memory::operator-=( address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) - rhs );
+}
+
+//-----------------------------------------------------------------------------
+
+inline bit::memory::address&
+  bit::memory::operator&=( address& lhs, address rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) &
+                                     static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline bit::memory::address&
+  bit::memory::operator&=( address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) & rhs );
+}
+
+inline bit::memory::address&
+  bit::memory::operator|=( address& lhs, address rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) |
+                                     static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline bit::memory::address&
+  bit::memory::operator|=( address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) | rhs );
+}
+
+inline bit::memory::address&
+  bit::memory::operator^=( address& lhs, address rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) ^
+                                     static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline bit::memory::address&
+  bit::memory::operator^=( address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<address>( static_cast<std::uintptr_t>(lhs) ^ rhs );
+}
+
+//-----------------------------------------------------------------------------
+// Binary Operators
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline constexpr bit::memory::address
+  bit::memory::operator+( address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) + rhs );
+}
+
+template<typename IntT, typename>
+inline constexpr bit::memory::address
+  bit::memory::operator+( IntT lhs, address rhs )
+  noexcept
+{
+  return static_cast<address>( lhs + static_cast<std::uintptr_t>(rhs) );
+}
+template<typename IntT, typename>
+inline constexpr bit::memory::address
+  bit::memory::operator-( address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) - rhs );
+}
+
+//-----------------------------------------------------------------------------
+
+inline constexpr bit::memory::address
+  bit::memory::operator~( address x )
+  noexcept
+{
+  return static_cast<address>( ~static_cast<std::uintptr_t>(x) );
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline constexpr bit::memory::address
+  bit::memory::operator&( address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) & rhs );
+}
+
+inline constexpr bit::memory::address
+  bit::memory::operator&( address lhs, address rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) &
+                               static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline constexpr bit::memory::address
+  bit::memory::operator|( address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) | rhs );
+}
+
+inline constexpr bit::memory::address
+  bit::memory::operator|( address lhs, address rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) |
+                               static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline constexpr bit::memory::address
+  bit::memory::operator^( address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) ^ rhs );
+}
+
+inline constexpr bit::memory::address
+  bit::memory::operator^( address lhs, address rhs )
+  noexcept
+{
+  return static_cast<address>( static_cast<std::uintptr_t>(lhs) ^
+                               static_cast<std::uintptr_t>(rhs) );
+}
+
+//=============================================================================
+// X.Y.2 : enum class const_address
+//=============================================================================
+
+//-----------------------------------------------------------------------------
+// Compound Operators
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline bit::memory::const_address&
+  bit::memory::operator+=( const_address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) + rhs );
+}
+
+template<typename IntT, typename>
+inline bit::memory::const_address&
+  bit::memory::operator-=( const_address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) - rhs );
+}
+
+//-----------------------------------------------------------------------------
+
+inline bit::memory::const_address&
+  bit::memory::operator&=( const_address& lhs, const_address rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) &
+                                           static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline bit::memory::const_address&
+  bit::memory::operator&=( const_address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) & rhs );
+}
+
+inline bit::memory::const_address&
+  bit::memory::operator|=( const_address& lhs, const_address rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) |
+                                           static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline bit::memory::const_address&
+  bit::memory::operator|=( const_address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) | rhs );
+}
+
+inline bit::memory::const_address&
+  bit::memory::operator^=( const_address& lhs, const_address rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) ^
+                                           static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline bit::memory::const_address&
+  bit::memory::operator^=( const_address& lhs, IntT rhs )
+  noexcept
+{
+  return lhs = static_cast<const_address>( static_cast<std::uintptr_t>(lhs) ^ rhs );
+}
+
+//-----------------------------------------------------------------------------
+// Binary Operators
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline constexpr bit::memory::const_address
+  bit::memory::operator+( const_address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) + rhs );
+}
+
+template<typename IntT, typename>
+inline constexpr bit::memory::const_address
+  bit::memory::operator+( IntT lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<const_address>( lhs + static_cast<std::uintptr_t>(rhs) );
+}
+template<typename IntT, typename>
+inline constexpr bit::memory::const_address
+  bit::memory::operator-( const_address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) - rhs );
+}
+
+//-----------------------------------------------------------------------------
+
+inline constexpr bit::memory::const_address
+  bit::memory::operator~( const_address x )
+  noexcept
+{
+  return static_cast<const_address>( ~static_cast<std::uintptr_t>(x) );
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename IntT, typename>
+inline constexpr bit::memory::const_address
+  bit::memory::operator&( const_address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) & rhs );
+}
+
+inline constexpr bit::memory::const_address
+  bit::memory::operator&( const_address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) &
+                                     static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline constexpr bit::memory::const_address
+  bit::memory::operator|( const_address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) | rhs );
+}
+
+inline constexpr bit::memory::const_address
+  bit::memory::operator|( const_address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) |
+                                     static_cast<std::uintptr_t>(rhs) );
+}
+
+template<typename IntT, typename>
+inline constexpr bit::memory::const_address
+  bit::memory::operator^( const_address lhs, IntT rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) ^ rhs );
+}
+
+inline constexpr bit::memory::const_address
+  bit::memory::operator^( const_address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<const_address>( static_cast<std::uintptr_t>(lhs) ^
+                                     static_cast<std::uintptr_t>(rhs) );
+}
+
+//=============================================================================
+// X.Y.3 : address/const_address utilities
+//=============================================================================
+
+inline bit::memory::address bit::memory::to_address( void* p )
+  noexcept
+{
+  return static_cast<address>( reinterpret_cast<std::uintptr_t>(p) );
+}
+
+inline bit::memory::const_address bit::memory::to_address( const void* p )
+  noexcept
+{
+  return static_cast<const_address>( reinterpret_cast<std::uintptr_t>(p) );
+}
+
+//-----------------------------------------------------------------------------
+
+inline void* bit::memory::to_pointer( address a )
+  noexcept
+{
+  return reinterpret_cast<void*>( static_cast<std::uintptr_t>(a) );
+}
+
+inline const void* bit::memory::to_pointer( const_address a )
+  noexcept
+{
+  return reinterpret_cast<const void*>( static_cast<std::uintptr_t>(a) );
+}
+
+//-----------------------------------------------------------------------------
+
+template<typename T>
+inline T* bit::memory::to_pointer( address a )
+  noexcept
+{
+  return static_cast<T*>( to_pointer(a) );
+}
+
+template<typename T>
+inline const T* bit::memory::to_pointer( const_address a )
+  noexcept
+{
+  return static_cast<const T*>( to_pointer(a) );
+}
+
+//=============================================================================
+// X.Y.4 : address/const_address comparisons
+//=============================================================================
+
+inline constexpr bool bit::memory::operator==( address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator==( const_address lhs, address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator!=( address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator!=( const_address lhs, address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator<( address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator<( const_address lhs, address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator>( address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator>( const_address lhs, address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator<=( address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator<=( const_address lhs, address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator>=( address lhs, const_address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+inline constexpr bool bit::memory::operator>=( const_address lhs, address rhs )
+  noexcept
+{
+  return static_cast<std::uintptr_t>(lhs)==static_cast<std::uintptr_t>(rhs);
+}
+
+#endif /* BIT_MEMORY_UTILITIES_DETAIL_ADDRESS_INL */

--- a/include/bit/memory/utilities/detail/pointer_utilities.inl
+++ b/include/bit/memory/utilities/detail/pointer_utilities.inl
@@ -241,21 +241,6 @@ inline void* bit::memory::offset_align_backward( void* p,
   const auto new_p   = reinterpret_cast<void*>(((address + offset) & (~static_cast<std::uintptr_t>(alignment-1))) - offset);
   return new_p;
 }
-//-----------------------------------------------------------------------------
-// Pointer Manipulation
-//-----------------------------------------------------------------------------
-
-inline std::uintptr_t bit::memory::to_address( void* ptr )
-noexcept
-{
-  return reinterpret_cast<std::uintptr_t>(ptr);
-}
-
-inline void* bit::memory::from_address( std::uintptr_t address )
-noexcept
-{
-  return reinterpret_cast<void*>(address);
-}
 
 //-----------------------------------------------------------------------------
 // Nullability

--- a/include/bit/memory/utilities/detail/uninitialized_storage.inl
+++ b/include/bit/memory/utilities/detail/uninitialized_storage.inl
@@ -118,10 +118,28 @@ inline T bit::memory::make_from_tuple( Tuple&& tuple )
 // Destruction
 //----------------------------------------------------------------------------
 
+namespace bit { namespace memory { namespace detail {
+
+  template<typename T>
+  inline void destroy_at_impl( T* p, std::false_type )
+  {
+    // trivial destructor; nothing to call
+  }
+
+  template<typename T>
+  inline void destroy_at_impl( T* p, std::true_type )
+  {
+    p->~T();
+  }
+
+} } } // namespace bit::memory::detail
+
 template<typename T>
 inline void bit::memory::destroy_at( T* p )
 {
-  p->~T();
+  static constexpr auto tag = std::is_trivially_destructible<T>{};
+
+  detail::destroy_at_impl( p, tag );
 }
 
 template<typename T>

--- a/include/bit/memory/utilities/macros.hpp
+++ b/include/bit/memory/utilities/macros.hpp
@@ -45,10 +45,13 @@
 #error BIT_MEMORY_ASSUME cannot be defined outside of macros.hpp
 #endif
 
+#ifdef BIT_MEMORY_UNREACHABLE
+#error BIT_MEMORY_UNREACHABLE cannot be defined outside of macros.hpp
+#endif
+
 #ifdef BIT_MEMORY_UNUSED
 #error BIT_MEMORY_UNUSED cannot be defined outside of macros.hpp
 #endif
-
 
 #ifdef __GNUC__
 #define BIT_MEMORY_LIKELY(x) __builtin_expect(!!(x),1)
@@ -68,6 +71,16 @@
 #define BIT_MEMORY_ASSUME(x) __assume(x)
 #else
 #define BIT_MEMORY_ASSUME(x) x
+#endif
+
+#if defined(__clang__)
+#define BIT_MEMORY_UNREACHABLE() __builtin_unreachable()
+#elif defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5)))
+#define BIT_MEMORY_UNREACHABLE() __builtin_unreachable()
+#elif defined(__MSC_VER)
+#define BIT_MEMORY_UNREACHABLE() __assume(0)
+#else
+#define BIT_MEMORY_UNREACHABLE()
 #endif
 
 #define BIT_MEMORY_UNUSED(x) (void) x

--- a/include/bit/memory/utilities/pointer_utilities.hpp
+++ b/include/bit/memory/utilities/pointer_utilities.hpp
@@ -203,24 +203,6 @@ namespace bit {
     /// \}
 
     //-------------------------------------------------------------------------
-    // Pointer Manipulation
-    //-------------------------------------------------------------------------
-
-    /// \brief Converts a pointer \p ptr into an integral type representing
-    ///        the address
-    ///
-    /// \param ptr the pointer to convert to an integral value
-    /// \return the numeric address of the given pointer
-    std::uintptr_t to_address( void* ptr ) noexcept;
-
-    /// \brief Converts a numeric address \p address into a pointer pointing
-    ///        to the address location
-    ///
-    /// \param address the address value to convert to a pointer
-    /// \return the pointer pointing to the given address
-    void* from_address( std::uintptr_t address ) noexcept;
-
-    //-------------------------------------------------------------------------
     // Nullability
     //-------------------------------------------------------------------------
 


### PR DESCRIPTION
### Objectives

* **Add `address` type**
This adds a new 'address' integral type. This is effectively a type-safe 
version of  `std::uintptr_t` that prevents the possibility of casting a 
`const T*` to an integral value and back to a `T*`. The `address` and 
`const_address` types both work to allow performing integral 
operations on an otherwise type-safe integral representation of 
a pointer's address

* **Add `BIT_MEMORY_UNREACHABLE`**
Certain codepaths should be considered completely unreachable, and
should be documented with this in order to promote better compiler
optimizations.
This is used in `allocator_traits` to instruct the compiler that invocation
of an out-of-memory handler must terminate the current codepath.

* **Optimize 'destroy_at' for pointer_utilities**
'destroy_at' will not call a pseudo-destructor if the type is trivial

* **Extend `allocator_traits`**
allocator_traits has been reworked to now include pointer conversions
from raw to pretty pointers and back.
\
Additionally, the extended-only logic of allocator_traits has now been
broken into a new traits type of 'extended_allocator_traits'. This
removes the need for SFINAE on non-existent implementations of
'try_allocate' with the extended offset.
